### PR TITLE
Add SDK server scripts and update workflows

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -8,6 +8,9 @@ on:
       - 'link/kalam-link-dart/**'
       - 'link/link-common/**'
       - 'backend/server.example.toml'
+      - 'scripts/download-release-server.sh'
+      - 'scripts/resolve-latest-release-asset.py'
+      - 'scripts/start-sdk-test-server.sh'
       - 'versions.json'
       - 'scripts/versions.py'
       - '.github/workflows/dart-sdk.yml'
@@ -73,36 +76,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=20"
-          RELEASES_JSON="$(curl -fsS \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "$API_URL")"
-
-          RELEASES_JSON="$RELEASES_JSON" python3 <<'PYTHON'
-          import json
-          import os
-          import re
-          import sys
-
-          releases = json.loads(os.environ["RELEASES_JSON"])
-          asset_pattern = re.compile(r"^kalamdb-server-.*-linux-x86_64\.tar\.gz$")
-
-          for release in releases:
-              if release.get("draft"):
-                  continue
-
-              for asset in release.get("assets", []):
-                  name = asset.get("name", "")
-                  if asset_pattern.match(name):
-                      with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-                          handle.write(f"release_tag={release['tag_name']}\n")
-                          handle.write(f"asset_name={name}\n")
-                          handle.write(f"asset_api_url={asset['url']}\n")
-                      sys.exit(0)
-
-          raise SystemExit("No released linux x86_64 kalamdb-server asset found in the latest GitHub releases.")
-          PYTHON
+          python3 scripts/resolve-latest-release-asset.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --github-output "$GITHUB_OUTPUT" \
+            --token "$GITHUB_TOKEN" \
+            --asset-pattern '^kalamdb-server-.*-linux-x86_64\.tar\.gz$'
 
   download_release_server_binary:
     name: Download Latest Released SDK Server Binary
@@ -115,25 +93,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          ASSET_NAME="${{ needs.resolve_versions.outputs.latest_server_asset_name }}"
-          ASSET_API_URL="${{ needs.resolve_versions.outputs.latest_server_asset_api_url }}"
-          mkdir -p release-server dist
-
-          curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/octet-stream" \
-            -o "dist/${ASSET_NAME}" \
-            "$ASSET_API_URL"
-
-          tar -xzf "dist/${ASSET_NAME}" -C release-server
-          EXTRACTED_BIN="$(find release-server -maxdepth 1 -type f -name 'kalamdb-server-*linux-x86_64' | head -n1)"
-          if [[ -z "$EXTRACTED_BIN" ]]; then
-            echo "Failed to locate kalamdb-server binary in ${ASSET_NAME}" >&2
-            exit 1
-          fi
-          chmod +x "$EXTRACTED_BIN"
-          mv "$EXTRACTED_BIN" release-server/kalamdb-server
+          bash scripts/download-release-server.sh \
+            "${{ needs.resolve_versions.outputs.latest_server_asset_name }}" \
+            "${{ needs.resolve_versions.outputs.latest_server_asset_api_url }}" \
+            "$PWD/release-server/kalamdb-server"
           echo "Using latest released SDK server from ${{ needs.resolve_versions.outputs.latest_server_release_tag }}"
 
       - name: Upload SDK test server binary
@@ -200,30 +163,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cp backend/server.example.toml server.toml
-          sed -i 's|data_path = "./data"|data_path = "./test-data"|g' server.toml
-          sed -i 's|logs_path = "./logs"|logs_path = "./test-data/logs"|g' server.toml
-          sed -i 's|jwt_secret = ".*"|jwt_secret = "sdk-test-secret-key-minimum-32-characters-long"|g' server.toml
-          mkdir -p test-data/rocksdb test-data/storage test-data/logs
-          ./kalamdb-server server.toml > dart-sdk-server.log 2>&1 &
-          SERVER_PID=$!
-          echo "SERVER_PID=$SERVER_PID" >> "$GITHUB_ENV"
-          for i in {1..120}; do
-            if curl -sf http://localhost:8080/health > /dev/null 2>&1 || curl -sf http://localhost:8080/v1/api/healthcheck > /dev/null 2>&1; then
-              echo "✅ SDK test server ready (${i}s)"
-              if [[ -s dart-sdk-server.log ]]; then
-                echo "Recent server log output:"
-                tail -n 40 dart-sdk-server.log || true
-              fi
-              exit 0
-            fi
-            kill -0 "$SERVER_PID" 2>/dev/null || { echo "❌ Server died"; cat dart-sdk-server.log; exit 1; }
-            echo "  Waiting... ($i/120)"
-            sleep 1
-          done
-          echo "❌ Timed out waiting for SDK test server"
-          cat dart-sdk-server.log || true
-          exit 1
+          SERVER_WORK_DIR="$PWD/sdk-test-server"
+          KALAMDB_SERVER_BIN="$PWD/kalamdb-server" \
+          KALAMDB_SERVER_WORK_DIR="$SERVER_WORK_DIR" \
+          KALAMDB_SERVER_LOG="$PWD/dart-sdk-server.log" \
+          KALAMDB_SERVER_PID_FILE="$SERVER_WORK_DIR/server.pid" \
+          KALAMDB_SERVER_WAIT_SECONDS="120" \
+          KALAMDB_URL="http://localhost:8080" \
+          bash scripts/start-sdk-test-server.sh
+          echo "SERVER_PID=$(cat "$SERVER_WORK_DIR/server.pid")" >> "$GITHUB_ENV"
 
       - name: Run Dart SDK tests
         id: run_tests

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -128,7 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-wheels, build-sdist]
     if: ${{ inputs.publish }}
-    environment: pypi
+    environment:
+      name: pypi
     permissions:
       id-token: write
 

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -9,6 +9,9 @@ on:
       - 'link/kalam-consumer-wasm/**'
       - 'link/link-common/**'
       - 'backend/server.example.toml'
+      - 'scripts/download-release-server.sh'
+      - 'scripts/resolve-latest-release-asset.py'
+      - 'scripts/start-sdk-test-server.sh'
       - 'scripts/test-typescript-sdk-release.sh'
       - 'versions.json'
       - 'scripts/versions.py'
@@ -86,36 +89,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=20"
-          RELEASES_JSON="$(curl -fsS \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "$API_URL")"
-
-          RELEASES_JSON="$RELEASES_JSON" python3 <<'PYTHON'
-          import json
-          import os
-          import re
-          import sys
-
-          releases = json.loads(os.environ["RELEASES_JSON"])
-          asset_pattern = re.compile(r"^kalamdb-server-.*-linux-x86_64\.tar\.gz$")
-
-          for release in releases:
-              if release.get("draft"):
-                  continue
-
-              for asset in release.get("assets", []):
-                  name = asset.get("name", "")
-                  if asset_pattern.match(name):
-                      with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-                          handle.write(f"release_tag={release['tag_name']}\n")
-                          handle.write(f"asset_name={name}\n")
-                          handle.write(f"asset_api_url={asset['url']}\n")
-                      sys.exit(0)
-
-          raise SystemExit("No released linux x86_64 kalamdb-server asset found in the latest GitHub releases.")
-          PYTHON
+          python3 scripts/resolve-latest-release-asset.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --github-output "$GITHUB_OUTPUT" \
+            --token "$GITHUB_TOKEN" \
+            --asset-pattern '^kalamdb-server-.*-linux-x86_64\.tar\.gz$'
 
   download_release_server_binary:
     name: Download Latest Released SDK Server Binary
@@ -128,25 +106,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          ASSET_NAME="${{ needs.resolve_versions.outputs.latest_server_asset_name }}"
-          ASSET_API_URL="${{ needs.resolve_versions.outputs.latest_server_asset_api_url }}"
-          mkdir -p release-server dist
-
-          curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/octet-stream" \
-            -o "dist/${ASSET_NAME}" \
-            "$ASSET_API_URL"
-
-          tar -xzf "dist/${ASSET_NAME}" -C release-server
-          EXTRACTED_BIN="$(find release-server -maxdepth 1 -type f -name 'kalamdb-server-*linux-x86_64' | head -n1)"
-          if [[ -z "$EXTRACTED_BIN" ]]; then
-            echo "Failed to locate kalamdb-server binary in ${ASSET_NAME}" >&2
-            exit 1
-          fi
-          chmod +x "$EXTRACTED_BIN"
-          mv "$EXTRACTED_BIN" release-server/kalamdb-server
+          bash scripts/download-release-server.sh \
+            "${{ needs.resolve_versions.outputs.latest_server_asset_name }}" \
+            "${{ needs.resolve_versions.outputs.latest_server_asset_api_url }}" \
+            "$PWD/release-server/kalamdb-server"
           echo "Using latest released SDK server from ${{ needs.resolve_versions.outputs.latest_server_release_tag }}"
 
       - name: Upload SDK test server binary

--- a/link/kalam-client/tests/proxied/topic_consumption_netem.rs
+++ b/link/kalam-client/tests/proxied/topic_consumption_netem.rs
@@ -193,7 +193,7 @@ fn records_with_op<'a>(records: &'a [ConsumerRecord], op: TopicOp) -> Vec<&'a Co
 }
 
 #[tokio::test]
-#[ntest::timeout(15000)]
+#[ntest::timeout(30000)]
 async fn test_tokio_netem_topic_consume_fragmented_insert_update_delete_and_commit() {
     let result = timeout(Duration::from_secs(60), async {
         let writer = match create_test_client() {
@@ -393,7 +393,7 @@ async fn test_tokio_netem_topic_bandwidth_collapse_poll_recovers_without_losing_
 }
 
 #[tokio::test]
-#[ntest::timeout(15000)]
+#[ntest::timeout(30000)]
 async fn test_tokio_netem_topic_commit_failure_can_be_retried_without_replay() {
     let result = timeout(Duration::from_secs(75), async {
         let writer = match create_test_client() {

--- a/link/kalam-client/tests/proxied/transport_impairments.rs
+++ b/link/kalam-client/tests/proxied/transport_impairments.rs
@@ -454,7 +454,7 @@ async fn test_proxy_packet_loss_style_stalls_resume_without_replay() {
 /// Very small write slices fragment WebSocket frames at the transport boundary.
 /// The client should parse the stream normally and avoid spurious reconnects.
 #[tokio::test]
-#[ntest::timeout(15000)]
+#[ntest::timeout(30000)]
 async fn test_tokio_netem_fragmented_writes_preserve_live_stream() {
     let result = timeout(Duration::from_secs(45), async {
         let writer = match create_test_client() {

--- a/pg/crates/kalam-pg-client/tests/statement_round_trip.rs
+++ b/pg/crates/kalam-pg-client/tests/statement_round_trip.rs
@@ -4,7 +4,7 @@
 //! a `RemoteKalamClient`, and exercises a full round-trip:
 //!     client → gRPC → KalamPgService → OperationExecutor → response → client
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use arrow::{
     array::{Array, Int64Array, StringArray},
@@ -19,6 +19,7 @@ use kalamdb_pg::{
     DeleteRequest, InsertRequest, KalamPgService, MutationResult, OperationExecutor,
     PgServiceServer, ScanRequest, ScanResult, UpdateRequest,
 };
+use tokio::net::TcpListener;
 use tonic::{Code, Status};
 
 // ---------------------------------------------------------------------------
@@ -145,7 +146,7 @@ async fn start_server(port: u16) {
 }
 
 async fn start_server_with_executor(host: &str, port: u16, executor: Arc<dyn OperationExecutor>) {
-    let bind_addr: SocketAddr = format!("{host}:{port}").parse().expect("bind addr");
+    let bind_addr = format!("{host}:{port}").parse().expect("bind addr");
     let service = KalamPgService::new(false, None).with_operation_executor(executor);
 
     tokio::spawn(async move {
@@ -157,6 +158,52 @@ async fn start_server_with_executor(host: &str, port: u16, executor: Arc<dyn Ope
     });
 
     tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+async fn start_server_with_executor_on_ephemeral_port(
+    host: &str,
+    executor: Arc<dyn OperationExecutor>,
+) -> u16 {
+    let listener = TcpListener::bind(format!("{host}:0"))
+        .await
+        .expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    let service = KalamPgService::new(false, None).with_operation_executor(executor);
+
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(PgServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("serve pg grpc");
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    port
+}
+
+fn leader_api_port_for_rpc_port(leader_rpc_port: u16) -> u16 {
+    leader_rpc_port
+        .checked_sub(1000)
+        .expect("ephemeral RPC port must support leader API mapping")
+}
+
+async fn start_leader_redirect_servers(host: &str, code: Code) -> (u16, u16) {
+    let leader_rpc_port =
+        start_server_with_executor_on_ephemeral_port(host, Arc::new(MockExecutor)).await;
+    let leader_api_port = leader_api_port_for_rpc_port(leader_rpc_port);
+    let follower_rpc_port = start_server_with_executor_on_ephemeral_port(
+        host,
+        Arc::new(NotLeaderExecutor {
+            leader_api_addr: format!("http://{host}:{leader_api_port}"),
+            code,
+        }),
+    )
+    .await;
+
+    (follower_rpc_port, leader_rpc_port)
 }
 
 async fn connect(port: u16) -> RemoteKalamClient {
@@ -237,20 +284,8 @@ async fn scan_with_projection_and_limit() {
 #[ntest::timeout(10000)]
 async fn scan_follows_leader_redirect_hint() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39081;
-    let leader_rpc_port = 39083;
-    let leader_api_port = 38083;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::Internal,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, _leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::Internal).await;
 
     let client = connect_to(host, follower_rpc_port).await;
     let session = client.open_session(None, Some("app")).await.expect("open session");
@@ -268,20 +303,8 @@ async fn scan_follows_leader_redirect_hint() {
 #[ntest::timeout(10000)]
 async fn execute_sql_follows_leader_redirect_hint() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39181;
-    let leader_rpc_port = 39183;
-    let leader_api_port = 38183;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::Internal,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, _leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::Internal).await;
 
     let client = connect_to(host, follower_rpc_port).await;
     let session = client.open_session(None, Some("app")).await.expect("open session");
@@ -298,20 +321,8 @@ async fn execute_sql_follows_leader_redirect_hint() {
 #[ntest::timeout(10000)]
 async fn execute_query_follows_leader_redirect_hint() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39281;
-    let leader_rpc_port = 39283;
-    let leader_api_port = 38283;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::Internal,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, _leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::Internal).await;
 
     let client = connect_to(host, follower_rpc_port).await;
     let session = client.open_session(None, Some("app")).await.expect("open session");
@@ -329,20 +340,8 @@ async fn execute_query_follows_leader_redirect_hint() {
 #[ntest::timeout(10000)]
 async fn insert_follows_leader_redirect_hint_from_failed_precondition() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39381;
-    let leader_rpc_port = 39383;
-    let leader_api_port = 38383;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::FailedPrecondition,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, _leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::FailedPrecondition).await;
 
     let client = connect_to(host, follower_rpc_port).await;
     let session = client.open_session(None, Some("app")).await.expect("open session");
@@ -366,20 +365,8 @@ async fn insert_follows_leader_redirect_hint_from_failed_precondition() {
 #[ntest::timeout(10000)]
 async fn begin_transaction_follows_leader_redirect_hint() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39481;
-    let leader_rpc_port = 39483;
-    let leader_api_port = 38483;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::FailedPrecondition,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, _leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::FailedPrecondition).await;
 
     let client = connect_to(host, follower_rpc_port).await;
     let session = client.open_session(None, Some("app")).await.expect("open session");
@@ -396,20 +383,8 @@ async fn begin_transaction_follows_leader_redirect_hint() {
 #[ntest::timeout(10000)]
 async fn commit_transaction_follows_leader_redirect_hint() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39581;
-    let leader_rpc_port = 39583;
-    let leader_api_port = 38583;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::FailedPrecondition,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::FailedPrecondition).await;
 
     let follower_client = connect_to(host, follower_rpc_port).await;
     let session = follower_client
@@ -439,20 +414,8 @@ async fn commit_transaction_follows_leader_redirect_hint() {
 #[ntest::timeout(10000)]
 async fn rollback_transaction_follows_leader_redirect_hint() {
     let host = "127.0.0.1";
-    let follower_rpc_port = 39681;
-    let leader_rpc_port = 39683;
-    let leader_api_port = 38683;
-
-    start_server_with_executor(
-        host,
-        follower_rpc_port,
-        Arc::new(NotLeaderExecutor {
-            leader_api_addr: format!("http://{host}:{leader_api_port}"),
-            code: Code::FailedPrecondition,
-        }),
-    )
-    .await;
-    start_server_with_executor(host, leader_rpc_port, Arc::new(MockExecutor)).await;
+    let (follower_rpc_port, leader_rpc_port) =
+        start_leader_redirect_servers(host, Code::FailedPrecondition).await;
 
     let follower_client = connect_to(host, follower_rpc_port).await;
     let session = follower_client

--- a/scripts/download-release-server.sh
+++ b/scripts/download-release-server.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <asset-name> <asset-api-url> <target-binary-path>" >&2
+    exit 1
+fi
+
+ASSET_NAME="$1"
+ASSET_API_URL="$2"
+TARGET_BINARY_PATH="$3"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="${SCRIPT_DIR}/../target/sdk-release-server"
+ARCHIVE_PATH="$WORK_DIR/$ASSET_NAME"
+EXTRACT_DIR="$WORK_DIR/extracted"
+
+mkdir -p "$WORK_DIR" "$EXTRACT_DIR" "$(dirname "$TARGET_BINARY_PATH")"
+rm -rf "$EXTRACT_DIR"
+mkdir -p "$EXTRACT_DIR"
+
+CURL_ARGS=(-fsSL -H "Accept: application/octet-stream")
+if [[ -n "$GITHUB_TOKEN" ]]; then
+    CURL_ARGS+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+curl "${CURL_ARGS[@]}" -o "$ARCHIVE_PATH" "$ASSET_API_URL"
+tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR"
+
+EXTRACTED_BIN="$(find "$EXTRACT_DIR" -type f -name 'kalamdb-server-*linux-x86_64' | head -n1)"
+if [[ -z "$EXTRACTED_BIN" ]]; then
+    echo "Failed to locate kalamdb-server binary in ${ASSET_NAME}" >&2
+    exit 1
+fi
+
+cp "$EXTRACTED_BIN" "$TARGET_BINARY_PATH"
+chmod +x "$TARGET_BINARY_PATH"

--- a/scripts/resolve-latest-release-asset.py
+++ b/scripts/resolve-latest-release-asset.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve the first GitHub release asset matching a pattern.",
+    )
+    parser.add_argument("--repository", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--github-output", required=True, help="Path to the GitHub Actions output file")
+    parser.add_argument("--asset-pattern", required=True, help="Regex for the desired asset name")
+    parser.add_argument("--token", default="", help="GitHub token used for the releases API request")
+    parser.add_argument("--per-page", type=int, default=20, help="How many releases to fetch")
+    return parser.parse_args()
+
+
+def fetch_releases(repository: str, token: str, per_page: int) -> list[dict]:
+    api_url = f"https://api.github.com/repos/{repository}/releases?per_page={per_page}"
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(api_url, headers=headers)
+    with urllib.request.urlopen(request) as response:
+        payload = json.load(response)
+
+    if not isinstance(payload, list):
+        raise RuntimeError(f"Unexpected releases payload type: {type(payload).__name__}")
+
+    return payload
+
+
+def write_outputs(output_path: str, release_tag: str, asset_name: str, asset_api_url: str) -> None:
+    with open(output_path, "a", encoding="utf-8") as handle:
+        handle.write(f"release_tag={release_tag}\n")
+        handle.write(f"asset_name={asset_name}\n")
+        handle.write(f"asset_api_url={asset_api_url}\n")
+
+
+def main() -> int:
+    args = parse_args()
+    asset_pattern = re.compile(args.asset_pattern)
+
+    try:
+        releases = fetch_releases(args.repository, args.token, args.per_page)
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"GitHub releases API request failed with {error.code}: {body}") from error
+    except urllib.error.URLError as error:
+        raise SystemExit(f"GitHub releases API request failed: {error.reason}") from error
+
+    for release in releases:
+        if release.get("draft"):
+            continue
+
+        for asset in release.get("assets", []):
+            name = asset.get("name", "")
+            if asset_pattern.match(name):
+                write_outputs(args.github_output, release["tag_name"], name, asset["url"])
+                return 0
+
+    raise SystemExit("No release asset matched the requested pattern.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/start-sdk-test-server.sh
+++ b/scripts/start-sdk-test-server.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SERVER_URL="${KALAMDB_URL:-http://localhost:8080}"
+SERVER_BIN="${KALAMDB_SERVER_BIN:-}"
+WORK_DIR="${KALAMDB_SERVER_WORK_DIR:-}"
+SERVER_LOG="${KALAMDB_SERVER_LOG:-}"
+SERVER_PID_FILE="${KALAMDB_SERVER_PID_FILE:-}"
+SERVER_TEMPLATE="${KALAMDB_SERVER_TEMPLATE:-$ROOT_DIR/backend/server.example.toml}"
+JWT_SECRET="${KALAMDB_JWT_SECRET:-sdk-test-secret-key-minimum-32-characters-long}"
+WAIT_SECONDS="${KALAMDB_SERVER_WAIT_SECONDS:-60}"
+
+if [[ -z "$WORK_DIR" || -z "$SERVER_LOG" ]]; then
+    echo "KALAMDB_SERVER_WORK_DIR and KALAMDB_SERVER_LOG are required." >&2
+    exit 1
+fi
+
+if [[ -n "$SERVER_BIN" && ! -x "$SERVER_BIN" ]]; then
+    chmod +x "$SERVER_BIN"
+fi
+
+healthcheck() {
+    curl -sf "$SERVER_URL/health" > /dev/null 2>&1 \
+        || curl -sf "$SERVER_URL/v1/api/healthcheck" > /dev/null 2>&1
+}
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/data" "$WORK_DIR/logs" "$(dirname "$SERVER_LOG")"
+cp "$SERVER_TEMPLATE" "$WORK_DIR/server.toml"
+
+perl -0pi -e 's|data_path = "\./data"|data_path = "'"$WORK_DIR"'/data"|g; s|logs_path = "\./logs"|logs_path = "'"$WORK_DIR"'/logs"|g; s|jwt_secret = ".*"|jwt_secret = "'"$JWT_SECRET"'"|g' "$WORK_DIR/server.toml"
+
+if [[ -n "$SERVER_BIN" ]]; then
+    SERVER_CMD=("$SERVER_BIN" "$WORK_DIR/server.toml")
+else
+    SERVER_CMD=(cargo run --manifest-path "$ROOT_DIR/backend/Cargo.toml" --bin kalamdb-server -- "$WORK_DIR/server.toml")
+fi
+
+(
+    cd "$ROOT_DIR"
+    KALAMDB_SERVER_HOST=0.0.0.0 \
+    KALAMDB_JWT_SECRET="$JWT_SECRET" \
+    "${SERVER_CMD[@]}" > "$SERVER_LOG" 2>&1
+) &
+SERVER_PID=$!
+
+if [[ -n "$SERVER_PID_FILE" ]]; then
+    mkdir -p "$(dirname "$SERVER_PID_FILE")"
+    printf '%s' "$SERVER_PID" > "$SERVER_PID_FILE"
+fi
+
+for ((i = 1; i <= WAIT_SECONDS; i++)); do
+    if healthcheck; then
+        echo "✅ SDK test server ready (${i}s)"
+        if [[ -s "$SERVER_LOG" ]]; then
+            echo "Recent SDK test server log output:"
+            tail -n 40 "$SERVER_LOG" || true
+        fi
+        exit 0
+    fi
+
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "❌ SDK test server died" >&2
+        cat "$SERVER_LOG" || true
+        exit 1
+    fi
+
+    echo "  Waiting for SDK test server... ($i/$WAIT_SECONDS)"
+    sleep 1
+done
+
+echo "❌ Timed out waiting for SDK test server" >&2
+cat "$SERVER_LOG" || true
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+exit 1

--- a/scripts/test-typescript-sdk-release.sh
+++ b/scripts/test-typescript-sdk-release.sh
@@ -191,53 +191,16 @@ run_selected_package() {
 trap cleanup EXIT
 
 if [[ "$SKIP_SERVER_START" != "true" ]]; then
-    : > "$SERVER_LOG"
-    rm -rf "$WORK_DIR"
-    mkdir -p "$WORK_DIR/data" "$WORK_DIR/logs"
-    cp "$ROOT_DIR/backend/server.example.toml" "$WORK_DIR/server.toml"
-
-    perl -0pi -e 's|data_path = "\./data"|data_path = "'"$WORK_DIR"'/data"|g; s|logs_path = "\./logs"|logs_path = "'"$WORK_DIR"'/logs"|g; s|jwt_secret = ".*"|jwt_secret = "'"$JWT_SECRET"'"|g' "$WORK_DIR/server.toml"
-
-    if [[ -n "$SERVER_BIN" ]]; then
-        SERVER_CMD=("$SERVER_BIN" "$WORK_DIR/server.toml")
-    else
-        SERVER_CMD=(cargo run --manifest-path "$ROOT_DIR/backend/Cargo.toml" --bin kalamdb-server -- "$WORK_DIR/server.toml")
-    fi
-
-    (
-        cd "$ROOT_DIR"
-        KALAMDB_SERVER_HOST=0.0.0.0 \
-        KALAMDB_JWT_SECRET="$JWT_SECRET" \
-        "${SERVER_CMD[@]}" > "$SERVER_LOG" 2>&1
-    ) &
-    SERVER_PID=$!
-fi
-
-for i in {1..60}; do
-    if curl -sf "$SERVER_URL/health" > /dev/null 2>&1 \
-        || curl -sf "$SERVER_URL/v1/api/healthcheck" > /dev/null 2>&1; then
-        echo "✅ TypeScript SDK test server ready (${i}s)"
-        break
-    fi
-    if [[ -n "$SERVER_PID" ]] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
-        echo "❌ TypeScript SDK test server died"
-        cat "$SERVER_LOG" || true
-        exit 1
-    fi
-    echo "  Waiting for TypeScript SDK test server... ($i/60)"
-    sleep 1
-done
-
-if ! curl -sf "$SERVER_URL/health" > /dev/null 2>&1 \
-    && ! curl -sf "$SERVER_URL/v1/api/healthcheck" > /dev/null 2>&1; then
-    echo "❌ Timed out waiting for TypeScript SDK test server"
-    cat "$SERVER_LOG" || true
-    exit 1
-fi
-
-if [[ -s "$SERVER_LOG" ]]; then
-    echo "Recent TypeScript SDK server log output:"
-    tail -n 40 "$SERVER_LOG" || true
+    SERVER_PID_FILE="$WORK_DIR/server.pid"
+    KALAMDB_SERVER_BIN="$SERVER_BIN" \
+    KALAMDB_SERVER_WORK_DIR="$WORK_DIR" \
+    KALAMDB_SERVER_LOG="$SERVER_LOG" \
+    KALAMDB_SERVER_PID_FILE="$SERVER_PID_FILE" \
+    KALAMDB_SERVER_WAIT_SECONDS="60" \
+    KALAMDB_JWT_SECRET="$JWT_SECRET" \
+    KALAMDB_URL="$SERVER_URL" \
+    bash "$ROOT_DIR/scripts/start-sdk-test-server.sh"
+    SERVER_PID="$(cat "$SERVER_PID_FILE")"
 fi
 
 ensure_test_auth_ready

--- a/scripts/versions.py
+++ b/scripts/versions.py
@@ -21,6 +21,24 @@ PROTOCOL = "v1"
 DEV_CHANNEL_CORE = "main"
 DEV_CHANNEL_STABILITY = "dev"
 
+DOCS_ARCHIVED_VERSIONS: dict[str, tuple[dict[str, str], ...]] = {
+    "server": (
+        {"slug": "0-4-2-rc-3", "label": "0.4.2-rc.3"},
+        {"slug": "0-4-1-beta", "label": "0.4.1-beta"},
+    ),
+    "pg-extension": (
+        {"slug": "0-4-2-rc-3", "label": "0.4.2-rc.3"},
+    ),
+    "typescript-sdk": (
+        {"slug": "0-4-2-rc-1", "label": "0.4.2-rc.1"},
+        {"slug": "0-4-1-beta", "label": "0.4.1-beta"},
+        {"slug": "0-4-x", "label": "0.4.x"},
+    ),
+    "dart-sdk": (
+        {"slug": "0-4-1-beta-2", "label": "0.4.1-beta.2"},
+    ),
+}
+
 WORKSPACE_CARGO = ROOT / "Cargo.toml"
 BACKEND_CARGO = ROOT / "backend" / "Cargo.toml"
 CLI_CARGO = ROOT / "cli" / "Cargo.toml"
@@ -183,6 +201,19 @@ def build_package_entry(version: str, compatible_core: str, depends_on: dict[str
     return entry
 
 
+def build_docs_manifest() -> dict[str, Any]:
+    return {
+        "versioning": {
+            "sections": {
+                section_id: {
+                    "archived": [dict(entry) for entry in archived_versions],
+                }
+                for section_id, archived_versions in DOCS_ARCHIVED_VERSIONS.items()
+            }
+        }
+    }
+
+
 def append_archived_release(existing: dict[str, Any] | None, current_core_version: str) -> list[dict[str, Any]]:
     archived = list(existing.get("archived", [])) if existing else []
     previous_latest = (existing or {}).get("channels", {}).get("latest", {})
@@ -250,6 +281,7 @@ def build_versions_manifest(existing: dict[str, Any] | None) -> dict[str, Any]:
                 "stability": DEV_CHANNEL_STABILITY,
             },
         },
+        "docs": build_docs_manifest(),
         "archived": append_archived_release(existing, core_version),
         "packages": {
             "core_components": {

--- a/versions.json
+++ b/versions.json
@@ -12,6 +12,56 @@
       "stability": "dev"
     }
   },
+  "docs": {
+    "versioning": {
+      "sections": {
+        "server": {
+          "archived": [
+            {
+              "slug": "0-4-2-rc-3",
+              "label": "0.4.2-rc.3"
+            },
+            {
+              "slug": "0-4-1-beta",
+              "label": "0.4.1-beta"
+            }
+          ]
+        },
+        "pg-extension": {
+          "archived": [
+            {
+              "slug": "0-4-2-rc-3",
+              "label": "0.4.2-rc.3"
+            }
+          ]
+        },
+        "typescript-sdk": {
+          "archived": [
+            {
+              "slug": "0-4-2-rc-1",
+              "label": "0.4.2-rc.1"
+            },
+            {
+              "slug": "0-4-1-beta",
+              "label": "0.4.1-beta"
+            },
+            {
+              "slug": "0-4-x",
+              "label": "0.4.x"
+            }
+          ]
+        },
+        "dart-sdk": {
+          "archived": [
+            {
+              "slug": "0-4-1-beta-2",
+              "label": "0.4.1-beta.2"
+            }
+          ]
+        }
+      }
+    }
+  },
   "archived": [],
   "packages": {
     "core_components": {


### PR DESCRIPTION
Introduce reusable scripts to resolve/download/start the SDK test server and refactor CI to use them. Adds scripts/resolve-latest-release-asset.py, scripts/download-release-server.sh and scripts/start-sdk-test-server.sh and wires these into the Dart and TypeScript GitHub Actions (also include the scripts in the workflow file triggers). Replace inline release-asset resolution and server extraction/bootstrapping with calls to the new scripts.

Other notable changes:
- Use a PID file and centralized server start logic in CI and scripts/test-typescript-sdk-release.sh.
- Increase several Rust test timeouts (ntest::timeout from 15000 to 30000) to reduce flakiness under network-impaired tests.
- Refactor PG client tests to start servers on ephemeral ports and add helper functions (start_server_with_executor_on_ephemeral_port, start_leader_redirect_servers) to remove duplicated port wiring.
- Minor change to python workflow environment syntax (environment name mapping).
- Add docs archived versions support in scripts/versions.py and update versions.json with docs/versioning archived entries.

These changes centralize server lifecycle handling, reduce duplicated CI code, and improve test reliability.
