### PR TITLE
Switch to live_events API across client/benches

### DIFF
--- a/benchv2/Cargo.lock
+++ b/benchv2/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "kalam-client"
-version = "0.4.3-rc.4"
+version = "0.5.0-beta.1"
 dependencies = [
  "link-common",
 ]
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "kalamdb-commons"
-version = "0.4.3-rc.4"
+version = "0.5.0-beta.1"
 dependencies = [
  "dashmap",
  "hex",
@@ -997,7 +997,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "link-common"
-version = "0.4.3-rc.4"
+version = "0.5.0-beta.1"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/benchv2/src/benchmarks/connection_scale_bench.rs
+++ b/benchv2/src/benchmarks/connection_scale_bench.rs
@@ -239,7 +239,7 @@ impl Benchmark for ConnectionScaleBench {
                                         format!("SELECT * FROM {}.conn_scale", namespace),
                                     );
                                     sub_config.ws_url = Some(ws_target.clone());
-                                    link.subscribe_with_config(sub_config).await
+                                    link.live_events_with_config(sub_config).await
                                 }) => {
                                     match result {
                                         Ok(Ok(sub)) => Ok(sub),
@@ -1104,7 +1104,9 @@ async fn validate_ws_targets(
         cfg.ws_url = Some(target.clone());
 
         let probe = client.new_isolated_link_for_ws_url(Some(target))?;
-        let result = tokio::time::timeout(TARGET_VALIDATE_TIMEOUT, probe.subscribe_with_config(cfg)).await;
+        let result =
+            tokio::time::timeout(TARGET_VALIDATE_TIMEOUT, probe.live_events_with_config(cfg))
+                .await;
         match result {
             Ok(Ok(mut subscription)) => {
                 let _ = subscription.close().await;

--- a/benchv2/src/benchmarks/load_subscriber_bench.rs
+++ b/benchv2/src/benchmarks/load_subscriber_bench.rs
@@ -69,7 +69,7 @@ impl Benchmark for ConcurrentSubscriberBench {
                     let sub_config = SubscriptionConfig::new(sub_name, sql);
 
                     let mut sub = link
-                        .subscribe_with_config(sub_config)
+                        .live_events_with_config(sub_config)
                         .await
                         .map_err(|e| format!("Subscribe #{} failed: {}", sub_id, e))?;
 

--- a/benchv2/src/benchmarks/subscriber_scale_bench.rs
+++ b/benchv2/src/benchmarks/subscriber_scale_bench.rs
@@ -427,7 +427,7 @@ impl Benchmark for SubscriberScaleBench {
                                 let sql = format!("SELECT * FROM {}.scale_sub", ns);
                                 let mut sub_config = SubscriptionConfig::without_initial_data(sub_name, sql);
                                 sub_config.ws_url = Some(target_ws_url.clone());
-                                link.subscribe_with_config(sub_config).await
+                                link.live_events_with_config(sub_config).await
                             }) => {
                                 match result {
                                     Ok(Ok(sub)) => Ok(sub),

--- a/benchv2/src/chat_runtime/chat_realtime_bench.rs
+++ b/benchv2/src/chat_runtime/chat_realtime_bench.rs
@@ -848,7 +848,7 @@ async fn create_subscription(
     loop {
         let config = SubscriptionConfig::without_initial_data(subscription_id.clone(), sql.clone());
 
-        match timeout(SUBSCRIBE_TIMEOUT, link.subscribe_with_config(config)).await {
+        match timeout(SUBSCRIBE_TIMEOUT, link.live_events_with_config(config)).await {
             Ok(Ok(subscription)) => return Ok(subscription),
             Ok(Err(error))
                 if attempts < CHAT_SUBSCRIBE_RETRY_ATTEMPTS

--- a/benchv2/src/client.rs
+++ b/benchv2/src/client.rs
@@ -328,7 +328,7 @@ impl KalamClient {
         let endpoint = self.pick_endpoint();
         endpoint
             .link
-            .subscribe(sql)
+            .live_events(sql)
             .await
             .map_err(|e| format!("Subscribe error: {}", e))
     }
@@ -346,7 +346,7 @@ impl KalamClient {
 
         endpoint
             .link
-            .subscribe_with_config(config)
+            .live_events_with_config(config)
             .await
             .map_err(|e| format!("Subscribe error: {}", e))
     }

--- a/cli/tests/smoke/topics/smoke_test_topic_high_load.rs
+++ b/cli/tests/smoke/topics/smoke_test_topic_high_load.rs
@@ -77,13 +77,6 @@ fn configured_server_type() -> Option<&'static str> {
     None
 }
 
-fn has_explicit_server_target() -> bool {
-    parse_test_arg("--url").is_some()
-        || parse_test_arg("--urls").is_some()
-        || std::env::var("KALAMDB_SERVER_URL").is_ok()
-        || std::env::var("KALAMDB_CLUSTER_URLS").is_ok()
-}
-
 fn configured_server_targets() -> Vec<String> {
     let mut targets = Vec::new();
 
@@ -154,7 +147,11 @@ fn should_use_local_visibility_timeout_config() -> bool {
         _ => {},
     }
 
-    !has_explicit_server_target() || should_trust_local_server_config_for_target()
+    // In implicit auto-detect mode we may have attached to an arbitrary running
+    // server, so only trust the repo-local config when the selected target is
+    // explicitly local (including the auto-started fresh-server path, which sets
+    // `KALAMDB_SERVER_URL`).
+    should_trust_local_server_config_for_target()
 }
 
 fn local_visibility_timeout_config_path() -> Option<PathBuf> {

--- a/link/kalam-client/Cargo.toml
+++ b/link/kalam-client/Cargo.toml
@@ -60,6 +60,11 @@ name = "test_subscription_cleanup"
 path = "tests/test_subscription_cleanup.rs"
 required-features = ["e2e-tests"]
 
+[[test]]
+name = "proxied"
+path = "tests/proxied.rs"
+required-features = ["e2e-tests"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tokio-netem = { workspace = true }

--- a/link/kalam-client/tests/proxied/transport_impairments.rs
+++ b/link/kalam-client/tests/proxied/transport_impairments.rs
@@ -680,7 +680,7 @@ async fn test_tokio_netem_bandwidth_collapse_forces_resume_without_replay() {
 /// tokio-netem can fail the transport from inside the I/O adapter instead of
 /// aborting the proxy task. The client should treat it as a normal disconnect.
 #[tokio::test]
-#[ntest::timeout(15000)]
+#[ntest::timeout(30000)]
 async fn test_tokio_netem_forced_transport_termination_recovers() {
     let result = timeout(Duration::from_secs(75), async {
         let writer = match create_test_client() {


### PR DESCRIPTION
Replace subscribe()/subscribe_with_config() calls with live_events()/live_events_with_config() in benchmarks, the client wrapper, and chat runtime to use the new live events API. Update CLI smoke test logic to always consult the selected target for trusting repo-local visibility timeout config (removing the separate explicit-target check) and add a clarifying comment. Add a new "proxied" test entry to link/kalam-client/Cargo.toml and increase the ntest timeout for the proxied transport impairment test from 15s to 30s to accommodate longer network-fault scenarios.
