### PR TITLE
fix(wasm): unique subscription IDs

### DIFF
--- a/link/link-common/src/wasm/client.rs
+++ b/link/link-common/src/wasm/client.rs
@@ -2,7 +2,10 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
     rc::Rc,
+    sync::atomic::{AtomicU64, Ordering},
 };
+
+static SUBSCRIPTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 use serde::Serialize;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -139,7 +142,11 @@ impl KalamClient {
             return Err(JsValue::from_str("Not connected to server. Call connect() first."));
         }
 
-        let subscription_id = format!("sub-{:x}", subscription_hash(&sql));
+        let subscription_id = format!(
+            "sub-{:x}-{}",
+            subscription_hash(&sql),
+            SUBSCRIPTION_COUNTER.fetch_add(1, Ordering::Relaxed),
+        );
         let (subscribe_promise, subscribe_resolve, subscribe_reject) = create_promise();
 
         self.subscription_state.borrow_mut().insert(


### PR DESCRIPTION
Subscription IDs derived from `hash(sql)` alone collide when two subs to the same query overlap (e.g. React 18 StrictMode mount → unmount → mount). The second registration overwrites the first `SubscriptionState`, and the materializer keeps emitting under the stale ID — surfacing as duplicate rows.

Appends an `AtomicU64` counter to keep IDs unique. Hash prefix preserved for log readability.

Verified: `cargo check --target wasm32-unknown-unknown` passes. No code parses the `sub-{hex}` format. Reconnect path reuses original IDs (unaffected).