### PR TITLE
Replace kalamstack with kalamdb across repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability reporting
-    url: https://github.com/kalamstack/KalamDB/security/policy
+    url: https://github.com/kalamdb/KalamDB/security/policy
     about: Do not open public issues for security bugs. Use the private reporting process described in the security policy.
   - name: Contribution guide
-    url: https://github.com/kalamstack/KalamDB/blob/main/CONTRIBUTION.md
+    url: https://github.com/kalamdb/KalamDB/blob/main/CONTRIBUTION.md
     about: Review local setup, build, and test commands before opening a contribution-related issue.
   - name: Documentation
     url: https://kalamdb.org/docs

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -484,7 +484,7 @@ jobs:
       PUBLISH_REGISTRY_URL: 'https://npm.pkg.github.com'
       PUBLISH_REGISTRY_NAME: 'GitHub Packages'
       PUBLISH_ACCESS: ''
-      PUBLISH_SCOPE_OVERRIDE: '@kalamstack'
+      PUBLISH_SCOPE_OVERRIDE: '@kalamdb'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -494,7 +494,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@kalamstack'
+          scope: '@kalamdb'
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -515,7 +515,7 @@ jobs:
           shared-key: github-packages-publish
           cache-on-failure: true
 
-      - name: Publish @kalamstack/client to GitHub Packages
+      - name: Publish @kalamdb/client to GitHub Packages
         shell: bash
         working-directory: link/sdks/typescript/client
         env:
@@ -530,7 +530,7 @@ jobs:
           chmod +x ./publish.sh
           ./publish.sh --version "$VERSION" $FORCE_FLAG
 
-      - name: Publish @kalamstack/consumer to GitHub Packages
+      - name: Publish @kalamdb/consumer to GitHub Packages
         shell: bash
         working-directory: link/sdks/typescript/consumer
         env:
@@ -545,7 +545,7 @@ jobs:
           chmod +x ./publish.sh
           ./publish.sh --version "$VERSION" $FORCE_FLAG
 
-      - name: Publish @kalamstack/orm to GitHub Packages
+      - name: Publish @kalamdb/orm to GitHub Packages
         shell: bash
         working-directory: link/sdks/typescript/orm
         env:
@@ -560,7 +560,7 @@ jobs:
           chmod +x ./publish.sh
           ./publish.sh --version "$VERSION" $FORCE_FLAG
 
-      - name: Publish @kalamstack/react to GitHub Packages
+      - name: Publish @kalamdb/react to GitHub Packages
         shell: bash
         working-directory: link/sdks/typescript/react
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ edition = "2021"
 rust-version = "1.92"
 authors = ["KalamDB Team"]
 license = "Apache-2.0"
-repository = "https://github.com/kalamstack/KalamDB"
+repository = "https://github.com/kalamdb/KalamDB"
 
 # Shared dependencies for all crates
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Agents and frontends use the same backend directly: SQL over HTTP for reads and 
 <p align="center">
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.92%2B-orange.svg" alt="Rust" /></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License" /></a>
-  <a href="https://github.com/kalamstack/KalamDB/actions/workflows/ci.yml"><img src="https://github.com/kalamstack/KalamDB/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://github.com/kalamstack/KalamDB/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kalamstack/KalamDB/main/.github/badges/tests.json" alt="Overall Tests" /></a>
-  <a href="https://github.com/kalamstack/KalamDB/releases"><img src="https://img.shields.io/github/v/release/kalamstack/KalamDB?display_name=tag" alt="Release" /></a>
+  <a href="https://github.com/kalamdb/KalamDB/actions/workflows/ci.yml"><img src="https://github.com/kalamdb/KalamDB/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/kalamdb/KalamDB/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kalamdb/KalamDB/main/.github/badges/tests.json" alt="Overall Tests" /></a>
+  <a href="https://github.com/kalamdb/KalamDB/releases"><img src="https://img.shields.io/github/v/release/kalamdb/KalamDB?display_name=tag" alt="Release" /></a>
   <a href="https://hub.docker.com/r/jamals86/kalamdb"><img src="https://img.shields.io/docker/pulls/jamals86/kalamdb" alt="Docker Pulls" /></a>
   <a href="https://hub.docker.com/r/jamals86/pg-kalam"><img src="https://img.shields.io/docker/pulls/jamals86/pg-kalam?label=pg-kalam%20docker" alt="pg-kalam Docker Pulls" /></a>
 </p>
@@ -22,8 +22,8 @@ Agents and frontends use the same backend directly: SQL over HTTP for reads and 
 <p align="center"><strong>SDKs</strong></p>
 
 <p align="center">
-  <a href="https://github.com/kalamstack/KalamDB/actions/workflows/typescript-sdk.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kalamstack/KalamDB/main/.github/badges/sdk-typescript-tests.json" alt="TypeScript SDK Tests" /></a>
-  <a href="https://github.com/kalamstack/KalamDB/actions/workflows/dart-sdk.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kalamstack/KalamDB/main/.github/badges/sdk-dart-tests.json" alt="Dart SDK Tests" /></a>
+  <a href="https://github.com/kalamdb/KalamDB/actions/workflows/typescript-sdk.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kalamdb/KalamDB/main/.github/badges/sdk-typescript-tests.json" alt="TypeScript SDK Tests" /></a>
+  <a href="https://github.com/kalamdb/KalamDB/actions/workflows/dart-sdk.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kalamdb/KalamDB/main/.github/badges/sdk-dart-tests.json" alt="Dart SDK Tests" /></a>
   <a href="https://www.npmjs.com/package/@kalamdb/client"><img src="https://img.shields.io/npm/v/%40kalamdb%2Fclient?label=typescript%20sdk" alt="TypeScript SDK" /></a>
   <a href="https://pub.dev/packages/kalam_link"><img src="https://img.shields.io/pub/v/kalam_link?label=dart%20sdk" alt="Dart SDK" /></a>
 </p>
@@ -87,20 +87,20 @@ See [examples/chat-with-ai](examples/chat-with-ai/README.md) for the base live a
 
 ```bash
 KALAMDB_JWT_SECRET="$(openssl rand -base64 32)" \
-curl -sSL https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/single/docker-compose.yml | docker-compose -f - up -d
+curl -sSL https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/single/docker-compose.yml | docker-compose -f - up -d
 ```
 
 ### 3-node cluster
 
 ```bash
 KALAMDB_JWT_SECRET="$(openssl rand -base64 32)" \
-curl -sSL https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/cluster/docker-compose.yml | docker-compose -f - up -d
+curl -sSL https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/cluster/docker-compose.yml | docker-compose -f - up -d
 ```
 
 ### Local run
 
 ```bash
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 cargo run --bin kalamdb-server
 ```

--- a/docker/REPO-README.md
+++ b/docker/REPO-README.md
@@ -65,13 +65,13 @@ curl -X POST http://localhost:2900/v1/api/sql \
 
 ### 📄 Single-node compose file
 
-- GitHub view: https://github.com/kalamstack/KalamDB/blob/main/docker/run/single/docker-compose.yml
-- Raw file: https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/single/docker-compose.yml
+- GitHub view: https://github.com/kalamdb/KalamDB/blob/main/docker/run/single/docker-compose.yml
+- Raw file: https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/single/docker-compose.yml
 
 ### 🧱 3-node cluster compose file
 
-- GitHub view: https://github.com/kalamstack/KalamDB/blob/main/docker/run/cluster/docker-compose.yml
-- Raw file: https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/cluster/docker-compose.yml
+- GitHub view: https://github.com/kalamdb/KalamDB/blob/main/docker/run/cluster/docker-compose.yml
+- Raw file: https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/cluster/docker-compose.yml
 
 ### ⚡ Start single node with compose
 
@@ -103,14 +103,14 @@ Single node:
 
 ```bash
 KALAMDB_JWT_SECRET=replace-with-a-32-char-secret \
-curl -sSL https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/single/docker-compose.yml | docker compose -f - up -d
+curl -sSL https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/single/docker-compose.yml | docker compose -f - up -d
 ```
 
 3-node cluster:
 
 ```bash
 KALAMDB_JWT_SECRET=replace-with-a-32-char-secret \
-curl -sSL https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/cluster/docker-compose.yml | docker compose -f - up -d
+curl -sSL https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/cluster/docker-compose.yml | docker compose -f - up -d
 ```
 
 ## 🖥️ Open the UI
@@ -271,7 +271,7 @@ docker volume rm kalamdb_data
 ## 🔗 Links
 
 - Docker Hub: https://hub.docker.com/r/jamals86/kalamdb
-- GitHub: https://github.com/kalamstack/KalamDB
+- GitHub: https://github.com/kalamdb/KalamDB
 - Docs: https://kalamdb.org/docs
-- Single-node compose: https://github.com/kalamstack/KalamDB/blob/main/docker/run/single/docker-compose.yml
-- Cluster compose: https://github.com/kalamstack/KalamDB/blob/main/docker/run/cluster/docker-compose.yml
+- Single-node compose: https://github.com/kalamdb/KalamDB/blob/main/docker/run/single/docker-compose.yml
+- Cluster compose: https://github.com/kalamdb/KalamDB/blob/main/docker/run/cluster/docker-compose.yml

--- a/docker/build/Dockerfile.prebuilt
+++ b/docker/build/Dockerfile.prebuilt
@@ -32,7 +32,7 @@ FROM ubuntu:24.04
 ARG OCI_IMAGE_TITLE="KalamDB"
 ARG OCI_IMAGE_DESCRIPTION="KalamDB database server"
 ARG OCI_IMAGE_URL="https://kalamdb.org"
-ARG OCI_IMAGE_SOURCE="https://github.com/kalamstack/KalamDB"
+ARG OCI_IMAGE_SOURCE="https://github.com/kalamdb/KalamDB"
 ARG OCI_IMAGE_DOCUMENTATION="https://kalamdb.org/docs"
 ARG OCI_IMAGE_VENDOR="KalamDB"
 ARG OCI_IMAGE_AUTHORS="Jamal Saad"

--- a/docs/development/development-setup.md
+++ b/docs/development/development-setup.md
@@ -142,7 +142,7 @@ $env:LIBCLANG_PATH
 
 ```powershell
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB\backend
 
 # Build the project (first build will take 10-20 minutes)
@@ -226,7 +226,7 @@ brew install pkg-config
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 # Build the project (first build will take 10-20 minutes)
@@ -282,7 +282,7 @@ cargo --version
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 # Build the project (first build will take 10-20 minutes)
@@ -330,7 +330,7 @@ cargo --version
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 # Build the project
@@ -374,7 +374,7 @@ cargo --version
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 # Build the project
@@ -692,7 +692,7 @@ If you encounter issues not covered here:
   - [macOS Setup Guide](macos.md#troubleshooting)
   - [Linux Setup Guide](linux.md#troubleshooting)
   - [Windows Setup Guide](windows.md#troubleshooting)
-2. **Check GitHub Issues**: [KalamDB Issues](https://github.com/kalamstack/KalamDB/issues)
+2. **Check GitHub Issues**: [KalamDB Issues](https://github.com/kalamdb/KalamDB/issues)
 3. **Search Rust Forums**: Many dependency issues are common across Rust projects
 4. **Enable Verbose Output**: `cargo build -vv` for detailed error messages
 5. **Check Dependencies**: Ensure all system dependencies are installed

--- a/docs/development/linux.md
+++ b/docs/development/linux.md
@@ -26,7 +26,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 
 # 3. Clone and build
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 cargo build
 ```
@@ -43,7 +43,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 
 # 3. Clone and build
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 cargo build
 ```
@@ -60,7 +60,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 
 # 3. Clone and build
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 cargo build
 ```
@@ -77,7 +77,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 
 # 3. Clone and build
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 cargo build
 ```
@@ -273,7 +273,7 @@ export CARGO_BUILD_JOBS=4
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 # First build (takes 10-20 minutes - compiles RocksDB, Arrow, Parquet)
@@ -457,7 +457,7 @@ sudo chown -R $USER:$USER ~/KalamDB
 # Or reclone without sudo
 cd ~
 rm -rf KalamDB
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 ```
 
 ---

--- a/docs/development/macos.md
+++ b/docs/development/macos.md
@@ -31,7 +31,7 @@ echo 'export DYLD_FALLBACK_LIBRARY_PATH="/Applications/Xcode.app/Contents/Develo
 source ~/.zshrc
 
 # 5. Clone and build
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 cargo build
 ```
@@ -187,7 +187,7 @@ brew install openssl@3
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 # First build (takes 10-20 minutes - compiles RocksDB, Arrow, Parquet)

--- a/docs/development/windows.md
+++ b/docs/development/windows.md
@@ -33,7 +33,7 @@ clang --version
 cargo --version
 
 # 5. Clone and build
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB\backend
 cargo build
 
@@ -199,7 +199,7 @@ winget install --id Git.Git -e --source winget
 
 ```powershell
 # Clone the repository
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB\backend
 
 # First build (takes 15-30 minutes on Windows - compiles RocksDB, Arrow, Parquet)

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -546,7 +546,7 @@ kalam --csv
 ## Support
 
 For issues, questions, or contributions:
-- GitHub: [github.com/kalamstack/KalamDB](https://github.com/kalamstack/KalamDB)
+- GitHub: [github.com/kalamdb/KalamDB](https://github.com/kalamdb/KalamDB)
 - Documentation: [docs/README.md](../README.md)
 
 ---

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -13,7 +13,7 @@ For full setup and troubleshooting, see [Development Setup](../development/devel
 ## 2. Clone and build
 
 ```bash
-git clone https://github.com/kalamstack/KalamDB.git
+git clone https://github.com/kalamdb/KalamDB.git
 cd KalamDB/backend
 
 cargo build --release --bin kalamdb-server

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 # ── Configurable ────────────────────────────────────────────────────────────
-GITHUB_REPO="kalamstack/KalamDB"
+GITHUB_REPO="kalamdb/KalamDB"
 BINARY_NAME="kalam"
 ARTIFACT_PREFIX="kalamcli"
 INSTALL_DIR="${KALAM_INSTALL_DIR:-$HOME/.kalam/bin}"

--- a/link/sdks/dart/README.md
+++ b/link/sdks/dart/README.md
@@ -8,7 +8,7 @@ KalamDB is a SQL-first realtime database. The current Dart SDK focuses on the ap
 
 Topic consumer / ACK worker APIs and initial server bootstrap flows are intentionally outside the Dart SDK surface.
 
-→ **[kalamdb.org](https://kalamdb.org)** · [Docs](https://kalamdb.org/docs) · [Dart setup](https://kalamdb.org/docs/sdk/dart/setup) · [Authentication](https://kalamdb.org/docs/sdk/dart/auth) · [Auth-aware client](https://kalamdb.org/docs/sdk/dart/auth-aware-client) · [Subscriptions](https://kalamdb.org/docs/sdk/dart/subscriptions) · [GitHub](https://github.com/kalamstack/KalamDB)
+→ **[kalamdb.org](https://kalamdb.org)** · [Docs](https://kalamdb.org/docs) · [Dart setup](https://kalamdb.org/docs/sdk/dart/setup) · [Authentication](https://kalamdb.org/docs/sdk/dart/auth) · [Auth-aware client](https://kalamdb.org/docs/sdk/dart/auth-aware-client) · [Subscriptions](https://kalamdb.org/docs/sdk/dart/subscriptions) · [GitHub](https://github.com/kalamdb/KalamDB)
 
 ## Features
 
@@ -42,7 +42,7 @@ Before using the Dart SDK, you need a running KalamDB server.
 The quickest local setup is the maintained Docker Compose flow:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/kalamstack/KalamDB/main/docker/run/single/docker-compose.yml -o docker-compose.yml
+curl -sSL https://raw.githubusercontent.com/kalamdb/KalamDB/main/docker/run/single/docker-compose.yml -o docker-compose.yml
 KALAMDB_JWT_SECRET="$(openssl rand -base64 32)" docker compose up -d
 ```
 
@@ -529,7 +529,7 @@ Licensed under the Apache License, Version 2.0 (`Apache-2.0`). See [../../../LIC
 - WebSocket protocol: [https://kalamdb.org/docs/api/websocket-protocol](https://kalamdb.org/docs/api/websocket-protocol)
 - Live query architecture: [https://kalamdb.org/docs/architecture/live-query](https://kalamdb.org/docs/architecture/live-query)
 - Getting started auth: [https://kalamdb.org/docs/getting-started/authentication](https://kalamdb.org/docs/getting-started/authentication)
-- GitHub: [https://github.com/kalamstack/KalamDB](https://github.com/kalamstack/KalamDB)
+- GitHub: [https://github.com/kalamdb/KalamDB](https://github.com/kalamdb/KalamDB)
 
 ---
 

--- a/link/sdks/dart/ios/kalam_link.podspec
+++ b/link/sdks/dart/ios/kalam_link.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version          = '0.1.3'
   s.summary          = 'KalamDB client SDK – iOS native (flutter_rust_bridge).'
   s.description      = 'Pre-built static library for the kalam_link Flutter plugin.'
-  s.homepage         = 'https://github.com/kalamstack/KalamDB'
+  s.homepage         = 'https://github.com/kalamdb/KalamDB'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }
   s.author           = { 'KalamDB' => 'info@kalamdb.com' }
   s.source           = { :path => '.' }

--- a/link/sdks/dart/macos/kalam_link.podspec
+++ b/link/sdks/dart/macos/kalam_link.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version          = '0.1.3'
   s.summary          = 'KalamDB client SDK – macOS native (flutter_rust_bridge).'
   s.description      = 'Pre-built dynamic library for the kalam_link Flutter plugin.'
-  s.homepage         = 'https://github.com/kalamstack/KalamDB'
+  s.homepage         = 'https://github.com/kalamdb/KalamDB'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }
   s.author           = { 'KalamDB' => 'info@kalamdb.com' }
   s.source           = { :path => '.' }

--- a/link/sdks/dart/pubspec.yaml
+++ b/link/sdks/dart/pubspec.yaml
@@ -1,8 +1,8 @@
 name: kalam_link
 description: KalamDB client SDK for Dart and Flutter — queries, live subscriptions, and authentication
 version: 0.5.1-beta.1
-homepage: https://github.com/kalamstack/KalamDB
-repository: https://github.com/kalamstack/KalamDB
+homepage: https://github.com/kalamdb/KalamDB
+repository: https://github.com/kalamdb/KalamDB
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/link/sdks/dart/web/pkg/package.json
+++ b/link/sdks/dart/web/pkg/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kalamstack/KalamDB"
+    "url": "https://github.com/kalamdb/KalamDB"
   },
   "files": [
     "kalam_link_dart_bg.wasm",

--- a/link/sdks/python/README.md
+++ b/link/sdks/python/README.md
@@ -1,6 +1,6 @@
 # KalamDB Python SDK
 
-Official Python SDK for [KalamDB](https://github.com/kalamstack/KalamDB) — a SQL-first realtime database for AI agents, chat products, and multi-tenant SaaS.
+Official Python SDK for [KalamDB](https://github.com/kalamdb/KalamDB) — a SQL-first realtime database for AI agents, chat products, and multi-tenant SaaS.
 
 Built on top of the Rust `kalam-client` core via PyO3, so the networking, reconnection, and protocol logic is shared with the TypeScript and Dart SDKs.
 

--- a/link/sdks/sync-versions.sh
+++ b/link/sdks/sync-versions.sh
@@ -55,6 +55,7 @@ python3 - \
   "$ROOT_VERSION" \
   "$INTERNAL_RANGE" \
   "$ROOT_DIR" \
+    "${PUBLISH_SCOPE_OVERRIDE:-}" \
   "$DART_PUBSPEC" \
   "$PYTHON_PYPROJECT" \
   "$PYTHON_CARGO" \
@@ -67,10 +68,11 @@ from pathlib import Path
 root_version = sys.argv[1]
 internal_range = sys.argv[2]
 root_dir = Path(sys.argv[3])
-dart_pubspec = Path(sys.argv[4])
-python_pyproject = Path(sys.argv[5])
-python_cargo = Path(sys.argv[6])
-typescript_packages = [Path(value) for value in sys.argv[7:]]
+typescript_scope_override = sys.argv[4].strip()
+dart_pubspec = Path(sys.argv[5])
+python_pyproject = Path(sys.argv[6])
+python_cargo = Path(sys.argv[7])
+typescript_packages = [Path(value) for value in sys.argv[8:]]
 internal_packages = {
     "@kalamdb/client",
     "@kalamdb/consumer",
@@ -84,6 +86,14 @@ def display(path: Path) -> str:
         return str(path.relative_to(root_dir))
     except ValueError:
         return str(path)
+
+
+def display_package_name(package_name: str) -> str:
+    if not typescript_scope_override or not package_name.startswith("@") or "/" not in package_name:
+        return package_name
+
+    _, package_suffix = package_name.split("/", 1)
+    return f"{typescript_scope_override}/{package_suffix}"
 
 
 def update_yaml_version(path: Path, new_version: str) -> None:
@@ -121,6 +131,8 @@ def update_toml_section_version(path: Path, section_name: str, new_version: str)
 
 for package_path in typescript_packages:
     package_data = json.loads(package_path.read_text(encoding="utf-8"))
+    package_name = package_data["name"]
+    rendered_package_name = display_package_name(package_name)
     package_data["version"] = root_version
 
     peer_dependencies = package_data.get("peerDependencies")
@@ -130,7 +142,7 @@ for package_path in typescript_packages:
                 peer_dependencies[dependency_name] = internal_range
 
     package_path.write_text(f"{json.dumps(package_data, indent=2)}\n", encoding="utf-8")
-    print(f"Updated {display(package_path)}: version -> {root_version}")
+    print(f"Updated {rendered_package_name} ({display(package_path)}): version -> {root_version}")
 
 update_yaml_version(dart_pubspec, root_version)
 update_toml_section_version(python_pyproject, "project", root_version)

--- a/link/sdks/typescript/README.md
+++ b/link/sdks/typescript/README.md
@@ -13,12 +13,12 @@ Use each package directory as the source of truth for its build, test, and publi
 
 | Directory | Source package | npm publish name | GitHub Packages name |
 | --- | --- | --- | --- |
-| `client/` | `@kalamdb/client` | `@kalamdb/client` | `@kalamstack/client` |
-| `consumer/` | `@kalamdb/consumer` | `@kalamdb/consumer` | `@kalamstack/consumer` |
-| `orm/` | `@kalamdb/orm` | `@kalamdb/orm` | `@kalamstack/orm` |
-| `react/` | `@kalamdb/react` | `@kalamdb/react` | `@kalamstack/react` |
+| `client/` | `@kalamdb/client` | `@kalamdb/client` | `@kalamdb/client` |
+| `consumer/` | `@kalamdb/consumer` | `@kalamdb/consumer` | `@kalamdb/consumer` |
+| `orm/` | `@kalamdb/orm` | `@kalamdb/orm` | `@kalamdb/orm` |
+| `react/` | `@kalamdb/react` | `@kalamdb/react` | `@kalamdb/react` |
 
-The source manifests stay on `@kalamdb/*`. The GitHub Packages publish lane stages temporary `@kalamstack/*` manifests during publish because GitHub Packages requires the package scope to match the repository owner namespace.
+The source manifests stay on `@kalamdb/*`. The GitHub Packages publish lane stages temporary `@kalamdb/*` manifests during publish because GitHub Packages requires the package scope to match the repository owner namespace.
 
 ## Version maintenance
 
@@ -73,7 +73,7 @@ Full package builds also compile/copy the package-specific WASM artifacts.
 The GitHub Actions workflow `.github/workflows/typescript-sdk.yml` owns publish automation for the TypeScript SDKs.
 
 - Manual input `publish=true` publishes the npm packages under `@kalamdb/*`.
-- Manual input `publish_github_packages=true` publishes the GitHub Packages variants under `@kalamstack/*`.
+- Manual input `publish_github_packages=true` publishes the GitHub Packages variants under `@kalamdb/*`.
 - Manual input `force_publish=true` asks each package `publish.sh` to attempt an unpublish and republish when the registry allows it.
 - Both publish lanes run only after the `client`, `consumer`, `orm`, and `react` test matrix passes.
 - Publish order matters: `client` first, then `consumer`, then `orm`, then `react`.

--- a/link/sdks/typescript/client/QUICKSTART.md
+++ b/link/sdks/typescript/client/QUICKSTART.md
@@ -134,4 +134,4 @@ main().catch(console.error);
 
 - Full SDK docs: [README.md](README.md)
 - SQL reference: https://kalamdb.org/docs/reference/sql
-- Workspace examples: https://github.com/kalamstack/KalamDB/tree/main/examples
+- Workspace examples: https://github.com/kalamdb/KalamDB/tree/main/examples

--- a/link/sdks/typescript/client/README.md
+++ b/link/sdks/typescript/client/README.md
@@ -6,7 +6,7 @@ Official TypeScript / JavaScript SDK for [KalamDB](https://kalamdb.org) — SQL,
 
 KalamDB is built for apps where every user or tenant owns a private data space. The same SQL can run for every signed-in customer, while USER tables ensure each query only touches that caller's data. On the frontend, the default realtime API is now `live()`: you get the current materialized row set, not a stream of low-level diff frames that your UI has to reconcile.
 
-→ **[kalamdb.org](https://kalamdb.org)** · [Docs](https://kalamdb.org/docs/sdk/typescript) · [GitHub](https://github.com/kalamstack/KalamDB)
+→ **[kalamdb.org](https://kalamdb.org)** · [Docs](https://kalamdb.org/docs/sdk/typescript) · [GitHub](https://github.com/kalamdb/KalamDB)
 
 `@kalamdb/client` provides:
 
@@ -305,7 +305,7 @@ The npm README examples are backed by SDK tests:
 - `getSubscriptions()` for active subscriptions and typed `lastSeqId` checkpoints
 
 Full docs: [kalamdb.org/docs/sdk/typescript](https://kalamdb.org/docs/sdk/typescript)
-- Issues: [github.com/kalamstack/KalamDB/issues](https://github.com/kalamstack/KalamDB/issues)
+- Issues: [github.com/kalamdb/KalamDB/issues](https://github.com/kalamdb/KalamDB/issues)
 
 ---
 

--- a/link/sdks/typescript/client/package.json
+++ b/link/sdks/typescript/client/package.json
@@ -7,11 +7,11 @@
   "author": "KalamDB Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kalamstack/KalamDB"
+    "url": "https://github.com/kalamdb/KalamDB"
   },
-  "homepage": "https://github.com/kalamstack/KalamDB#readme",
+  "homepage": "https://github.com/kalamdb/KalamDB#readme",
   "bugs": {
-    "url": "https://github.com/kalamstack/KalamDB/issues"
+    "url": "https://github.com/kalamdb/KalamDB/issues"
   },
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",

--- a/link/sdks/typescript/consumer/package.json
+++ b/link/sdks/typescript/consumer/package.json
@@ -7,11 +7,11 @@
   "author": "KalamDB Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kalamstack/KalamDB"
+    "url": "https://github.com/kalamdb/KalamDB"
   },
-  "homepage": "https://github.com/kalamstack/KalamDB#readme",
+  "homepage": "https://github.com/kalamdb/KalamDB#readme",
   "bugs": {
-    "url": "https://github.com/kalamstack/KalamDB/issues"
+    "url": "https://github.com/kalamdb/KalamDB/issues"
   },
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",

--- a/link/sdks/typescript/orm/package.json
+++ b/link/sdks/typescript/orm/package.json
@@ -7,11 +7,11 @@
   "author": "KalamDB Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kalamstack/KalamDB"
+    "url": "https://github.com/kalamdb/KalamDB"
   },
-  "homepage": "https://github.com/kalamstack/KalamDB#readme",
+  "homepage": "https://github.com/kalamdb/KalamDB#readme",
   "bugs": {
-    "url": "https://github.com/kalamstack/KalamDB/issues"
+    "url": "https://github.com/kalamdb/KalamDB/issues"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/link/sdks/typescript/react/package.json
+++ b/link/sdks/typescript/react/package.json
@@ -7,11 +7,11 @@
   "author": "KalamDB Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kalamstack/KalamDB"
+    "url": "https://github.com/kalamdb/KalamDB"
   },
-  "homepage": "https://github.com/kalamstack/KalamDB#readme",
+  "homepage": "https://github.com/kalamdb/KalamDB#readme",
   "bugs": {
-    "url": "https://github.com/kalamstack/KalamDB/issues"
+    "url": "https://github.com/kalamdb/KalamDB/issues"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/specs/007-user-auth/contracts/auth.yaml
+++ b/specs/007-user-auth/contracts/auth.yaml
@@ -14,7 +14,7 @@ info:
   version: 1.0.0
   contact:
     name: KalamDB Team
-    url: https://github.com/kalamstack/KalamDB
+    url: https://github.com/kalamdb/KalamDB
 
 servers:
   - url: http://localhost:3000

--- a/specs/008-schema-consolidation/008-schema-consolidation.md
+++ b/specs/008-schema-consolidation/008-schema-consolidation.md
@@ -473,7 +473,7 @@ cargo test --workspace
 **Not Applicable**: This feature includes only internal refactoring with full backward compatibility. No rollback needed.
 
 If you encounter issues:
-1. File a bug report: https://github.com/kalamstack/KalamDB/issues
+1. File a bug report: https://github.com/kalamdb/KalamDB/issues
 2. Check troubleshooting section above
 3. Reach out on Discord: https://discord.gg/kalamdb
 
@@ -501,7 +501,7 @@ If you encounter issues:
 
 ### Support
 
-- **GitHub Issues**: https://github.com/kalamstack/KalamDB/issues
+- **GitHub Issues**: https://github.com/kalamdb/KalamDB/issues
 - **Discord Community**: https://discord.gg/kalamdb
 - **Email**: support@kalamdb.com
 

--- a/specs/008-schema-consolidation/quickstart.md
+++ b/specs/008-schema-consolidation/quickstart.md
@@ -11,7 +11,7 @@ This guide helps you get started with the schema consolidation codebase, underst
 ## Prerequisites
 
 - Rust 1.90+ installed (`rustup update stable`)
-- Git repository cloned: `git clone https://github.com/kalamstack/KalamDB.git`
+- Git repository cloned: `git clone https://github.com/kalamdb/KalamDB.git`
 - Familiarity with:
   - Rust 2021 edition
   - Apache Arrow & DataFusion

--- a/specs/012-full-dml-support/TROUBLESHOOTING.md
+++ b/specs/012-full-dml-support/TROUBLESHOOTING.md
@@ -331,7 +331,7 @@ RUST_BACKTRACE=1 cargo build -vv
 ### Get Help
 
 1. Check [Full Troubleshooting Guide](DEVELOPMENT_SETUP.md#troubleshooting)
-2. Search [GitHub Issues](https://github.com/kalamstack/KalamDB/issues)
+2. Search [GitHub Issues](https://github.com/kalamdb/KalamDB/issues)
 3. Open a new issue with:
    - Your OS and version
    - Rust version (`rustc --version`)


### PR DESCRIPTION
Update repository owner namespace and package scope references from `kalamstack` to `kalamdb` across docs, CI, manifests, and scripts. Notable changes:

- CI/workflow: .github/workflows/typescript-sdk.yml updated to use `@kalamdb` scope and to rename publish job labels.
- Package metadata: updated repository/homepage/bugs URLs in multiple package.json, pubspec.yaml, podspecs, and README files to point to github.com/kalamdb/KalamDB.
- Docs and examples: README, docker/REPO-README.md, and many docs/ and specs/ files updated for clone/raw URLs and issue links.
- Installer and build: Cargo.toml repository, install.sh GITHUB_REPO, and docker/build/Dockerfile.prebuilt OCI_IMAGE_SOURCE updated.
- TypeScript SDK docs: link/sdks/typescript README adjusted to publish under `@kalamdb/*` and related notes.
- sync-versions.sh: enhanced to accept an optional TypeScript scope override, added display_package_name() to render overridden package names, and improved update logging to show rendered package names.

These changes standardize the project namespace to `kalamdb` and align CI, publishing, and documentation with the new owner scope.
