### PR TITLE
Stream: windowed file layout, eviction, minute buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,6 +4822,7 @@ dependencies = [
  "kalamdb-system",
  "kalamdb-tables",
  "log",
+ "ntest",
  "parking_lot",
  "serde",
  "serde_json",

--- a/backend/crates/kalamdb-commons/src/models/auth_type.rs
+++ b/backend/crates/kalamdb-commons/src/models/auth_type.rs
@@ -8,9 +8,15 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum AuthType {
-    #[cfg_attr(feature = "serde", serde(alias = "internal"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(alias = "internal", alias = "Internal", alias = "Password")
+    )]
     Password,
-    #[cfg_attr(feature = "serde", serde(alias = "oauth"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(alias = "oauth", alias = "OAuth", alias = "Oidc")
+    )]
     Oidc,
 }
 
@@ -57,5 +63,34 @@ impl From<&str> for AuthType {
 impl From<String> for AuthType {
     fn from(s: String) -> Self {
         AuthType::from(s.as_str())
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_to_lowercase_wire_values() {
+        assert_eq!(serde_json::to_string(&AuthType::Password).unwrap(), "\"password\"");
+        assert_eq!(serde_json::to_string(&AuthType::Oidc).unwrap(), "\"oidc\"");
+    }
+
+    #[test]
+    fn deserializes_legacy_title_case_wire_values() {
+        let password: AuthType = serde_json::from_str("\"Password\"").unwrap();
+        let oidc: AuthType = serde_json::from_str("\"Oidc\"").unwrap();
+
+        assert_eq!(password, AuthType::Password);
+        assert_eq!(oidc, AuthType::Oidc);
+    }
+
+    #[test]
+    fn deserializes_legacy_alias_wire_values() {
+        let internal: AuthType = serde_json::from_str("\"Internal\"").unwrap();
+        let oauth: AuthType = serde_json::from_str("\"OAuth\"").unwrap();
+
+        assert_eq!(internal, AuthType::Password);
+        assert_eq!(oauth, AuthType::Oidc);
     }
 }

--- a/backend/crates/kalamdb-commons/src/models/role.rs
+++ b/backend/crates/kalamdb-commons/src/models/role.rs
@@ -11,10 +11,15 @@ use serde::{Deserialize, Serialize};
     serde(rename_all = "lowercase")
 )]
 pub enum Role {
+    #[cfg_attr(feature = "serde", serde(alias = "Anonymous"))]
     Anonymous,
+    #[cfg_attr(feature = "serde", serde(alias = "User"))]
     User,
+    #[cfg_attr(feature = "serde", serde(alias = "Service"))]
     Service,
+    #[cfg_attr(feature = "serde", serde(alias = "Dba"))]
     Dba,
+    #[cfg_attr(feature = "serde", serde(alias = "System"))]
     System,
 }
 
@@ -70,5 +75,34 @@ impl From<&str> for Role {
 impl From<String> for Role {
     fn from(s: String) -> Self {
         Role::from(s.as_str())
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_to_lowercase_wire_values() {
+        assert_eq!(serde_json::to_string(&Role::Anonymous).unwrap(), "\"anonymous\"");
+        assert_eq!(serde_json::to_string(&Role::User).unwrap(), "\"user\"");
+        assert_eq!(serde_json::to_string(&Role::Service).unwrap(), "\"service\"");
+        assert_eq!(serde_json::to_string(&Role::Dba).unwrap(), "\"dba\"");
+        assert_eq!(serde_json::to_string(&Role::System).unwrap(), "\"system\"");
+    }
+
+    #[test]
+    fn deserializes_legacy_title_case_wire_values() {
+        let anonymous: Role = serde_json::from_str("\"Anonymous\"").unwrap();
+        let user: Role = serde_json::from_str("\"User\"").unwrap();
+        let service: Role = serde_json::from_str("\"Service\"").unwrap();
+        let dba: Role = serde_json::from_str("\"Dba\"").unwrap();
+        let system: Role = serde_json::from_str("\"System\"").unwrap();
+
+        assert_eq!(anonymous, Role::Anonymous);
+        assert_eq!(user, Role::User);
+        assert_eq!(service, Role::Service);
+        assert_eq!(dba, Role::Dba);
+        assert_eq!(system, Role::System);
     }
 }

--- a/backend/crates/kalamdb-jobs/Cargo.toml
+++ b/backend/crates/kalamdb-jobs/Cargo.toml
@@ -57,3 +57,4 @@ doctest = false
 [dev-dependencies]
 kalamdb-core = { path = "../kalamdb-core", features = ["test-helpers"] }
 tempfile = { workspace = true }
+ntest = { workspace = true }

--- a/backend/crates/kalamdb-jobs/src/executors/stream_eviction.rs
+++ b/backend/crates/kalamdb-jobs/src/executors/stream_eviction.rs
@@ -145,12 +145,20 @@ impl JobExecutor for StreamEvictionExecutor {
         let store = stream_provider.store_arc();
         let (cutoff_ms, _cutoff_seq) = compute_cutoff_window(params.ttl_seconds)?;
 
-        store.has_logs_before(cutoff_ms).map_err(|e| {
-            KalamDbError::InvalidOperation(format!(
-                "Failed to scan stream logs during pre-validation: {}",
-                e
-            ))
-        })
+        tokio::task::spawn_blocking(move || store.has_logs_before(cutoff_ms))
+            .await
+            .map_err(|e| {
+                KalamDbError::InvalidOperation(format!(
+                    "Stream eviction pre-validation task panicked: {}",
+                    e
+                ))
+            })?
+            .map_err(|e| {
+                KalamDbError::InvalidOperation(format!(
+                    "Failed to scan stream logs during pre-validation: {}",
+                    e
+                ))
+            })
     }
 
     async fn execute(&self, ctx: &JobContext<Self::Params>) -> Result<JobDecision, KalamDbError> {
@@ -201,9 +209,17 @@ impl JobExecutor for StreamEvictionExecutor {
                 ))
             })?;
         let store = stream_provider.store_arc();
-        let deleted_count = store.delete_old_logs(cutoff_ms).map_err(|e| {
-            KalamDbError::InvalidOperation(format!("Failed to delete old stream logs: {}", e))
-        })?;
+        let deleted_count = tokio::task::spawn_blocking(move || store.delete_old_logs(cutoff_ms))
+            .await
+            .map_err(|e| {
+                KalamDbError::InvalidOperation(format!(
+                    "Stream eviction cleanup task panicked: {}",
+                    e
+                ))
+            })?
+            .map_err(|e| {
+                KalamDbError::InvalidOperation(format!("Failed to delete old stream logs: {}", e))
+            })?;
 
         if deleted_count == 0 {
             ctx.log_info("No expired rows found; nothing to evict");
@@ -213,13 +229,13 @@ impl JobExecutor for StreamEvictionExecutor {
         }
 
         ctx.log_info(&format!(
-            "Stream eviction completed - {} log files removed from {}",
+            "Stream eviction completed - {} stream log window(s)/legacy file(s) removed from {}",
             deleted_count, table_id
         ));
 
         Ok(JobDecision::Completed {
             message: Some(format!(
-                "Evicted {} expired log files from {} (ttl: {}s)",
+                "Evicted {} expired stream log window(s)/legacy file(s) from {} (ttl: {}s)",
                 deleted_count, table_id, ttl_seconds
             )),
         })
@@ -240,15 +256,22 @@ impl Default for StreamEvictionExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::{BTreeMap, HashMap},
+        fs,
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
 
     use chrono::Utc;
-    use datafusion::datasource::TableProvider;
+    use datafusion::{datasource::TableProvider, scalar::ScalarValue};
     use kalamdb_commons::{
+        ids::StreamTableRowId,
         models::{
             datatypes::KalamDataType,
+            rows::Row,
             schemas::{ColumnDefinition, TableDefinition, TableOptions, TableType},
-            TableId, TableName, UserId,
+            StreamTableRow, TableId, TableName, UserId,
         },
         ChangeNotification, JobId, NamespaceId, NodeId,
     };
@@ -299,10 +322,19 @@ mod tests {
         namespace: NamespaceId,
         table_name_value: String,
         provider: Arc<StreamTableProvider>,
+        stream_base_dir: PathBuf,
         _stream_temp_dir: tempfile::TempDir,
     }
 
     fn setup_stream_table(app_ctx: &Arc<AppContext>) -> StreamTestHarness {
+        setup_stream_table_with_mode(app_ctx, kalamdb_tables::StreamTableStorageMode::Memory, 1)
+    }
+
+    fn setup_stream_table_with_mode(
+        app_ctx: &Arc<AppContext>,
+        storage_mode: kalamdb_tables::StreamTableStorageMode,
+        ttl_seconds: u64,
+    ) -> StreamTestHarness {
         let namespace = NamespaceId::new("chat_stream_jobs");
         let table_name_value =
             format!("typing_events_{}", Utc::now().timestamp_nanos_opt().unwrap_or(0));
@@ -317,7 +349,7 @@ mod tests {
                 ColumnDefinition::primary_key(1, "event_id", 1, KalamDataType::Text),
                 ColumnDefinition::simple(2, "payload", 2, KalamDataType::Text),
             ],
-            TableOptions::stream(1),
+            TableOptions::stream(ttl_seconds),
             None,
         )
         .expect("table definition");
@@ -325,18 +357,19 @@ mod tests {
         app_ctx.schema_registry().put(table_def).expect("Failed to put table def");
 
         let stream_temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let stream_base_dir = stream_temp_dir
+            .path()
+            .join("streams")
+            .join(namespace.as_str())
+            .join(table_name_value.as_str());
         let stream_store = Arc::new(kalamdb_tables::new_stream_table_store(
             &table_id,
             StreamTableStoreConfig {
-                base_dir: stream_temp_dir
-                    .path()
-                    .join("streams")
-                    .join(namespace.as_str())
-                    .join(table_name_value.as_str()),
+                base_dir: stream_base_dir.clone(),
                 max_rows_per_user: 256, // Default per-user retention limit
                 shard_router: ShardRouter::default_config(),
-                ttl_seconds: Some(1),
-                storage_mode: kalamdb_tables::StreamTableStorageMode::Memory,
+                ttl_seconds: Some(ttl_seconds),
+                storage_mode,
             },
         ));
         let tables_schema_registry =
@@ -374,7 +407,36 @@ mod tests {
             namespace,
             table_name_value,
             provider,
+            stream_base_dir,
             _stream_temp_dir: stream_temp_dir,
+        }
+    }
+
+    fn count_regular_files(path: &Path) -> usize {
+        let Ok(entries) = fs::read_dir(path) else {
+            return 0;
+        };
+
+        let mut count = 0usize;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                count += count_regular_files(&path);
+            } else if path.is_file() {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    fn stream_row(user: &UserId, seq: SeqId) -> StreamTableRow {
+        let mut values = BTreeMap::new();
+        values.insert("event_id".to_string(), ScalarValue::Utf8(Some("old-event".to_string())));
+        values.insert("payload".to_string(), ScalarValue::Utf8(Some("expired".to_string())));
+        StreamTableRow {
+            user_id: user.clone(),
+            _seq: seq,
+            fields: Row::new(values),
         }
     }
 
@@ -428,6 +490,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ntest::timeout(5000)]
     async fn test_execute_evicts_expired_rows_from_provider_store() {
         let app_ctx = test_app_context_simple();
         let harness = setup_stream_table(&app_ctx);
@@ -482,6 +545,70 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ntest::timeout(5000)]
+    async fn test_execute_removes_file_backed_expired_window_completely() {
+        let app_ctx = test_app_context_simple();
+        let harness = setup_stream_table_with_mode(
+            &app_ctx,
+            kalamdb_tables::StreamTableStorageMode::File,
+            60,
+        );
+
+        let user = UserId::new("user-file-ttl");
+        let old_ts = (Utc::now().timestamp_millis() as u64).saturating_sub(3 * 60 * 1000);
+        let old_seq = SeqId::new(
+            SnowflakeGenerator::max_id_for_timestamp(old_ts).expect("max_id_for_timestamp failed"),
+        );
+        let row_id = StreamTableRowId::new(user.clone(), old_seq);
+        let row = stream_row(&user, old_seq);
+        let store = harness.provider.store_arc();
+        store.put(&row_id, &row).expect("put old file-backed row");
+        store.flush().expect("flush file-backed row");
+
+        assert!(
+            count_regular_files(&harness.stream_base_dir) > 0,
+            "expected stream log file before eviction"
+        );
+
+        let mut job =
+            make_job("SE-file-evict", JobType::StreamEviction, harness.namespace.as_str());
+        job.parameters = Some(serde_json::json!({
+            "namespace_id": harness.namespace.as_str(),
+            "table_name": harness.table_name_value.clone(),
+            "table_type": "Stream",
+            "ttl_seconds": 60,
+            "batch_size": 100
+        }));
+
+        let params = StreamEvictionParams {
+            table_id: harness.table_id.clone(),
+            table_type: TableType::Stream,
+            ttl_seconds: 60,
+            batch_size: 100,
+        };
+
+        let ctx = JobContext::new(app_ctx.clone(), job.job_id.as_str().to_string(), params);
+        let executor = StreamEvictionExecutor::new();
+        let decision = executor.execute(&ctx).await.expect("execute file-backed eviction");
+
+        match decision {
+            JobDecision::Completed { message } => {
+                assert!(message.unwrap().contains("Evicted"));
+            },
+            other => panic!("Expected Completed decision, got {:?}", other),
+        }
+
+        assert_eq!(
+            count_regular_files(&harness.stream_base_dir),
+            0,
+            "expired stream files should be removed completely"
+        );
+        let remaining_rows = store.scan_all(None).expect("scan store after file eviction");
+        assert_eq!(remaining_rows.len(), 0, "Expired file-backed rows should be removed");
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(5000)]
     async fn test_pre_validate_skips_when_no_expired_rows() {
         let app_ctx = test_app_context_simple();
         let harness = setup_stream_table(&app_ctx);
@@ -508,6 +635,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ntest::timeout(5000)]
     async fn test_pre_validate_detects_expired_rows() {
         let app_ctx = test_app_context_simple();
         let harness = setup_stream_table(&app_ctx);

--- a/backend/crates/kalamdb-observability/src/query_metrics.rs
+++ b/backend/crates/kalamdb-observability/src/query_metrics.rs
@@ -194,7 +194,6 @@ pub fn observe_query(kind: QueryMetricKind, latency: Duration, failed: bool) {
 
     let latency_micros = latency.as_micros().min(u64::MAX as u128) as u64;
     TOTAL_QUERY_LATENCY_MICROS.fetch_add(latency_micros, Ordering::Relaxed);
-
 }
 
 /// Snapshot SQL query counters without taking locks or scanning query state.

--- a/backend/crates/kalamdb-streams/src/file_store.rs
+++ b/backend/crates/kalamdb-streams/src/file_store.rs
@@ -21,7 +21,7 @@ use crate::{
     record::StreamLogRecord,
     store_trait::StreamLogStore,
     time_bucket::StreamTimeBucket,
-    utils::{cleanup_empty_dir, parse_log_window, parse_tmp_log_window, visit_dirs, visit_files},
+    utils::{cleanup_empty_dir, visit_dirs},
 };
 
 /// Write buffer capacity per segment file handle (64 KB).
@@ -40,11 +40,24 @@ const MAX_OPEN_SEGMENTS: usize = 256;
 /// Number of cold segment writers to close when the cache exceeds its cap.
 const SEGMENT_EVICT_BATCH: usize = 32;
 
+/// Suffix for a per-user stream log file inside a window/shard directory.
+const USER_LOG_FILE_SUFFIX: &str = ".log";
+
+/// Prefix for window directories: `w<start_ms>-<duration_ms>`.
+const WINDOW_DIR_PREFIX: &str = "w";
+
 /// Cached state for an open segment file.
 struct SegmentWriter {
     writer: BufWriter<File>,
     record_count: u32,
     last_write: Instant,
+}
+
+#[derive(Debug, Clone)]
+struct LogFileEntry {
+    window_start: u64,
+    window_end: u64,
+    path: PathBuf,
 }
 
 /// File-based stream log store with cached file handles and write buffering.
@@ -169,33 +182,48 @@ impl FileStreamLogStore {
     }
 
     pub fn delete_old_logs_with_count(&self, before_time: u64) -> Result<usize> {
-        let mut deleted = 0usize;
         let base_dir = &self.config.base_dir;
         if !base_dir.exists() {
             return Ok(0);
         }
 
-        visit_dirs(base_dir, |bucket_dir| {
-            visit_dirs(&bucket_dir, |shard_dir| {
-                visit_dirs(&shard_dir, |user_dir| {
-                    visit_files(&user_dir, |log_file| {
-                        if self.delete_if_expired(&log_file, before_time)? {
-                            deleted += 1;
-                        }
-                        Ok(true)
-                    })?;
-                    cleanup_empty_dir(&user_dir);
-                    Ok(true)
-                })?;
-                cleanup_empty_dir(&shard_dir);
-                Ok(true)
-            })?;
-            cleanup_empty_dir(&bucket_dir);
+        let deleted = self.delete_expired_windows(before_time)?;
+        cleanup_empty_dir(base_dir);
+
+        Ok(deleted)
+    }
+
+    fn delete_expired_windows(&self, before_time: u64) -> Result<usize> {
+        let base_dir = &self.config.base_dir;
+        if !base_dir.exists() {
+            return Ok(0);
+        }
+
+        let mut expired_dirs = Vec::new();
+        visit_dirs(base_dir, |window_dir| {
+            if let Some((_window_start, window_end)) = Self::parse_window_dir(&window_dir)
+            {
+                if window_end <= before_time {
+                    expired_dirs.push(window_dir);
+                }
+            }
             Ok(true)
         })?;
 
-        cleanup_empty_dir(base_dir);
+        let mut deleted = 0usize;
+        for window_dir in expired_dirs {
+            self.close_segments_under(&window_dir);
+            match fs::remove_dir_all(&window_dir) {
+                Ok(()) => {
+                    deleted += 1;
+                    self.close_segments_under(&window_dir);
+                },
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {},
+                Err(err) => return Err(StreamLogError::Io(err.to_string())),
+            }
+        }
 
+        cleanup_empty_dir(base_dir);
         Ok(deleted)
     }
 
@@ -205,21 +233,25 @@ impl FileStreamLogStore {
             return Ok(false);
         }
 
-        let mut found = false;
-        visit_dirs(base_dir, |bucket_dir| {
-            visit_dirs(&bucket_dir, |shard_dir| {
-                visit_dirs(&shard_dir, |user_dir| {
-                    visit_files(&user_dir, |log_file| {
-                        if self.is_expired_log_or_tmp(&log_file, before_time) {
-                            found = true;
-                            return Ok(false);
-                        }
-                        Ok(true)
-                    })
-                })
-            })
-        })?;
+        self.has_expired_window(before_time)
+    }
 
+    fn has_expired_window(&self, before_time: u64) -> Result<bool> {
+        let base_dir = &self.config.base_dir;
+        if !base_dir.exists() {
+            return Ok(false);
+        }
+
+        let mut found = false;
+        visit_dirs(base_dir, |window_dir| {
+            if let Some((_window_start, window_end)) = Self::parse_window_dir(&window_dir) {
+                if window_end <= before_time {
+                    found = true;
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        })?;
         Ok(found)
     }
 
@@ -230,40 +262,9 @@ impl FileStreamLogStore {
             return Ok(Vec::new());
         }
 
-        visit_dirs(base_dir, |bucket_dir| {
-            visit_dirs(&bucket_dir, |shard_dir| {
-                visit_dirs(&shard_dir, |user_dir| {
-                    if let Some(name) = user_dir.file_name().and_then(|n| n.to_str()) {
-                        users.insert(UserId::new(name));
-                    }
-                    Ok(true)
-                })
-            })
-        })?;
+        self.collect_user_ids(&mut users)?;
 
         Ok(users.into_iter().collect())
-    }
-
-    fn is_expired_log_or_tmp(&self, path: &Path, before_time: u64) -> bool {
-        let Some(window_start) = parse_log_window(path).or_else(|| parse_tmp_log_window(path))
-        else {
-            return false;
-        };
-        let window_end = window_start.saturating_add(self.config.bucket.duration_ms());
-        window_end < before_time
-    }
-
-    fn delete_if_expired(&self, path: &Path, before_time: u64) -> Result<bool> {
-        if !self.is_expired_log_or_tmp(path, before_time) {
-            return Ok(false);
-        }
-
-        self.close_segment(path);
-        match fs::remove_file(path) {
-            Ok(()) => Ok(true),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(err) => Err(StreamLogError::Io(err.to_string())),
-        }
     }
 
     fn close_segment(&self, path: &Path) -> bool {
@@ -274,6 +275,22 @@ impl FileStreamLogStore {
             return true;
         }
         false
+    }
+
+    fn close_segments_under(&self, dir: &Path) -> usize {
+        let paths: Vec<PathBuf> = self
+            .segments
+            .iter()
+            .filter(|entry| entry.key().starts_with(dir))
+            .map(|entry| entry.key().clone())
+            .collect();
+        let mut closed = 0usize;
+        for path in paths {
+            if self.close_segment(&path) {
+                closed += 1;
+            }
+        }
+        closed
     }
 
     fn prune_open_segments_if_needed(&self) {
@@ -316,6 +333,10 @@ impl FileStreamLogStore {
         };
 
         match self.config.bucket {
+            StreamTimeBucket::Minute => {
+                let truncated = dt.with_second(0).and_then(|v| v.with_nanosecond(0));
+                truncated.map(|v| v.timestamp_millis() as u64).unwrap_or(ts_ms)
+            },
             StreamTimeBucket::Hour => {
                 let truncated = dt
                     .with_minute(0)
@@ -346,24 +367,39 @@ impl FileStreamLogStore {
         }
     }
 
-    fn bucket_folder(&self, window_start_ms: u64) -> String {
-        let dt = Utc
-            .timestamp_millis_opt(window_start_ms as i64)
-            .single()
-            .unwrap_or_else(|| Utc.timestamp_millis_opt(0).single().unwrap());
-        match self.config.bucket {
-            StreamTimeBucket::Hour => dt.format("%Y%m%d%H").to_string(),
-            StreamTimeBucket::Day => dt.format("%Y%m%d").to_string(),
-            StreamTimeBucket::Week => dt.format("%G%V").to_string(),
-            StreamTimeBucket::Month => dt.format("%Y%m").to_string(),
-        }
+    fn window_dir(&self, window_start_ms: u64) -> PathBuf {
+        self.config.base_dir.join(format!(
+            "{}{}-{}",
+            WINDOW_DIR_PREFIX,
+            window_start_ms,
+            self.config.bucket.duration_ms()
+        ))
+    }
+
+    fn parse_window_dir(path: &Path) -> Option<(u64, u64)> {
+        let name = path.file_name()?.to_str()?;
+        let body = name.strip_prefix(WINDOW_DIR_PREFIX)?;
+        let (start, duration) = body.split_once('-')?;
+        let window_start = start.parse::<u64>().ok()?;
+        let duration_ms = duration.parse::<u64>().ok()?;
+        Some((window_start, window_start.saturating_add(duration_ms)))
+    }
+
+    fn user_log_file_name(user_id: &UserId) -> String {
+        format!("{}{}", user_id.as_str(), USER_LOG_FILE_SUFFIX)
+    }
+
+    fn parse_user_id_from_log_path(path: &Path) -> Option<UserId> {
+        let name = path.file_name()?.to_str()?;
+        let user_id = name.strip_suffix(USER_LOG_FILE_SUFFIX)?;
+        UserId::try_new(user_id.to_string()).ok()
     }
 
     fn log_path(&self, user_id: &UserId, window_start_ms: u64) -> PathBuf {
-        let bucket_folder = self.bucket_folder(window_start_ms);
         let shard = self.config.shard_router.route_stream_user(user_id).folder_name();
-        let user_dir = self.config.base_dir.join(bucket_folder).join(shard).join(user_id.as_str());
-        user_dir.join(format!("{}.log", window_start_ms))
+        self.window_dir(window_start_ms)
+            .join(shard)
+            .join(Self::user_log_file_name(user_id))
     }
 
     /// Ensure the parent directory of `path` exists, using the dir cache to
@@ -483,29 +519,73 @@ impl FileStreamLogStore {
         Ok(records)
     }
 
-    fn list_log_files_for_user(&self, user_id: &UserId) -> Result<Vec<(u64, PathBuf)>> {
+    fn collect_user_ids(&self, users: &mut HashSet<UserId>) -> Result<()> {
+        let base_dir = &self.config.base_dir;
+        if !base_dir.exists() {
+            return Ok(());
+        }
+
+        visit_dirs(base_dir, |window_dir| {
+            if Self::parse_window_dir(&window_dir).is_none() {
+                return Ok(true);
+            }
+            visit_dirs(&window_dir, |shard_dir| {
+                for entry in fs::read_dir(&shard_dir).map_err(|e| StreamLogError::Io(e.to_string()))? {
+                    let entry = entry.map_err(|e| StreamLogError::Io(e.to_string()))?;
+                    let path = entry.path();
+                    if !path.is_file() {
+                        continue;
+                    }
+                    if let Some(user_id) = Self::parse_user_id_from_log_path(&path) {
+                        users.insert(user_id);
+                    }
+                }
+                Ok(true)
+            })
+        })?;
+
+        Ok(())
+    }
+
+    fn list_log_files_for_user(&self, user_id: &UserId) -> Result<Vec<LogFileEntry>> {
         let mut entries = Vec::new();
         let base_dir = &self.config.base_dir;
         if !base_dir.exists() {
             return Ok(entries);
         }
 
+        self.collect_log_files_for_user(user_id, &mut entries)?;
+
+        Ok(entries)
+    }
+
+    fn collect_log_files_for_user(
+        &self,
+        user_id: &UserId,
+        entries: &mut Vec<LogFileEntry>,
+    ) -> Result<()> {
+        let base_dir = &self.config.base_dir;
+        if !base_dir.exists() {
+            return Ok(());
+        }
+
         let shard = self.config.shard_router.route_stream_user(user_id).folder_name();
-        visit_dirs(base_dir, |bucket_dir| {
-            let user_dir = bucket_dir.join(&shard).join(user_id.as_str());
-            if !user_dir.exists() {
+        visit_dirs(base_dir, |window_dir| {
+            let Some((window_start, window_end)) = Self::parse_window_dir(&window_dir) else {
                 return Ok(true);
+            };
+            let log_file = window_dir.join(&shard).join(Self::user_log_file_name(user_id));
+            if log_file.is_file() {
+                entries.push(LogFileEntry {
+                    window_start,
+                    window_end,
+                    path: log_file,
+                });
             }
-            visit_files(&user_dir, |log_file| {
-                if let Some(window_start) = parse_log_window(&log_file) {
-                    entries.push((window_start, log_file));
-                }
-                Ok(true)
-            })?;
             Ok(true)
         })?;
 
-        Ok(entries)
+        Ok(())
     }
 
     fn list_log_files_for_user_in_range(
@@ -513,34 +593,30 @@ impl FileStreamLogStore {
         user_id: &UserId,
         start_time: u64,
         end_time: u64,
-    ) -> Result<Vec<(u64, PathBuf)>> {
-        let bucket_ms = self.config.bucket.duration_ms();
+    ) -> Result<Vec<LogFileEntry>> {
         let mut entries = self.list_log_files_for_user(user_id)?;
-        entries.retain(|(window_start, _)| {
-            let window_end = window_start.saturating_add(bucket_ms);
-            *window_start <= end_time && window_end >= start_time
-        });
-        entries.sort_by_key(|(window_start, _)| *window_start);
+        entries.retain(|entry| entry.window_start <= end_time && entry.window_end > start_time);
+        entries.sort_by_key(|entry| entry.window_start);
         Ok(entries)
     }
 
-    fn list_log_files_for_user_latest(&self, user_id: &UserId) -> Result<Vec<(u64, PathBuf)>> {
+    fn list_log_files_for_user_latest(&self, user_id: &UserId) -> Result<Vec<LogFileEntry>> {
         let mut entries = self.list_log_files_for_user(user_id)?;
-        entries.sort_by(|a, b| b.0.cmp(&a.0));
+        entries.sort_by(|a, b| b.window_start.cmp(&a.window_start));
         Ok(entries)
     }
 
     fn collect_range_from_entries(
         &self,
-        entries: &[(u64, PathBuf)],
+        entries: &[LogFileEntry],
         limit: usize,
     ) -> Result<Vec<(StreamTableRowId, StreamTableRow)>> {
         let mut results: Vec<(StreamTableRowId, StreamTableRow)> = Vec::new();
         let mut deleted: HashSet<i64> = HashSet::new();
 
-        for (_window_start, path) in entries {
-            self.flush_segment(path);
-            let should_continue = Self::visit_records(path, |record| {
+        for entry in entries {
+            self.flush_segment(&entry.path);
+            let should_continue = Self::visit_records(&entry.path, |record| {
                 match record {
                     StreamLogRecord::Put { row_id, row } => {
                         let seq = row_id.seq().as_i64();
@@ -600,9 +676,9 @@ impl FileStreamLogStore {
         let mut results: Vec<(StreamTableRowId, StreamTableRow)> = Vec::new();
         let mut deleted: HashSet<i64> = HashSet::new();
 
-        for (_window_start, path) in &entries {
-            self.flush_segment(path);
-            let records = Self::read_records(path)?;
+        for entry in &entries {
+            self.flush_segment(&entry.path);
+            let records = Self::read_records(&entry.path)?;
             for record in records.into_iter().rev() {
                 match record {
                     StreamLogRecord::Put { row_id, row } => {
@@ -741,6 +817,11 @@ mod tests {
             .unwrap_or_else(|| chrono::Utc.timestamp_millis_opt(0).single().unwrap());
 
         match bucket {
+            StreamTimeBucket::Minute => dt
+                .with_second(0)
+                .and_then(|v| v.with_nanosecond(0))
+                .map(|v| v.timestamp_millis() as u64)
+                .unwrap_or(ts_ms),
             StreamTimeBucket::Hour => dt
                 .with_minute(0)
                 .and_then(|v| v.with_second(0))
@@ -765,19 +846,6 @@ mod tests {
                 .and_then(|d| d.and_hms_opt(0, 0, 0))
                 .map(|v| chrono::Utc.from_utc_datetime(&v).timestamp_millis() as u64)
                 .unwrap_or(ts_ms),
-        }
-    }
-
-    fn bucket_folder(bucket: StreamTimeBucket, window_start_ms: u64) -> String {
-        let dt = chrono::Utc
-            .timestamp_millis_opt(window_start_ms as i64)
-            .single()
-            .unwrap_or_else(|| chrono::Utc.timestamp_millis_opt(0).single().unwrap());
-        match bucket {
-            StreamTimeBucket::Hour => dt.format("%Y%m%d%H").to_string(),
-            StreamTimeBucket::Day => dt.format("%Y%m%d").to_string(),
-            StreamTimeBucket::Week => dt.format("%G%V").to_string(),
-            StreamTimeBucket::Month => dt.format("%Y%m").to_string(),
         }
     }
 
@@ -829,25 +897,25 @@ mod tests {
 
         store.append_rows(&table_id, &user_id, rows).expect("append_rows failed");
 
-        let shard_folder = shard_router.route_stream_user(&user_id).folder_name();
         let old_window = window_start_ms(bucket, old_ts);
         let new_window = window_start_ms(bucket, new_ts);
-        let old_bucket = bucket_folder(bucket, old_window);
-        let new_bucket = bucket_folder(bucket, new_window);
-
-        let old_path = base_dir
-            .join(old_bucket.clone())
-            .join(&shard_folder)
-            .join(user_id.as_str())
-            .join(format!("{}.log", old_window));
-        let new_path = base_dir
-            .join(new_bucket.clone())
-            .join(&shard_folder)
-            .join(user_id.as_str())
-            .join(format!("{}.log", new_window));
+        let old_path = store.log_path(&user_id, old_window);
+        let new_path = store.log_path(&user_id, new_window);
+        let old_window_dir = store.window_dir(old_window);
 
         assert!(old_path.exists(), "expected old log file to exist");
         assert!(new_path.exists(), "expected new log file to exist");
+        assert_eq!(
+            old_path.file_name().and_then(|name| name.to_str()),
+            Some("user-1.log"),
+            "expected stream rows to be stored directly as <user_id>.log"
+        );
+        assert_ne!(
+            old_path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str()),
+            Some(user_id.as_str()),
+            "expected no per-user directory in the stream file layout"
+        );
+        assert_eq!(store.open_segment_count(), 2);
         assert!(
             store
                 .has_logs_before(now_ms.saturating_sub(60 * 60 * 1000))
@@ -862,41 +930,10 @@ mod tests {
 
         assert!(!old_path.exists(), "expected old log file to be deleted");
         assert!(new_path.exists(), "expected new log file to remain");
+        assert_eq!(store.open_segment_count(), 1);
 
-        let old_bucket_dir = base_dir.join(old_bucket);
-        assert!(!old_bucket_dir.exists(), "expected old bucket directory to be removed");
+        assert!(!old_window_dir.exists(), "expected old window directory to be removed");
         assert!(base_dir.exists(), "expected base dir to remain");
-
-        let _ = fs::remove_dir_all(&base_dir);
-    }
-
-    #[test]
-    fn test_delete_old_logs_cleans_stale_tmp_files() {
-        let base_dir = temp_base_dir("kalamdb_streams_delete_tmp");
-        let table_id = TableId::new(NamespaceId::new("test_ns"), TableName::new("events"));
-        let shard_router = ShardRouter::new(4, 1);
-        let bucket = StreamTimeBucket::Hour;
-        let store = create_store(base_dir.clone(), table_id, shard_router.clone(), bucket);
-
-        let user_id = UserId::new("user-tmp");
-        let now_ms = chrono::Utc::now().timestamp_millis() as u64;
-        let old_ts = now_ms.saturating_sub(3 * 60 * 60 * 1000);
-        let old_window = window_start_ms(bucket, old_ts);
-        let old_bucket = bucket_folder(bucket, old_window);
-        let tmp_path = base_dir
-            .join(old_bucket)
-            .join(shard_router.route_stream_user(&user_id).folder_name())
-            .join(user_id.as_str())
-            .join(format!("{}.log.tmp", old_window));
-        fs::create_dir_all(tmp_path.parent().unwrap()).unwrap();
-        fs::write(&tmp_path, b"partial").unwrap();
-
-        let deleted = store
-            .delete_old_logs_with_count(now_ms.saturating_sub(60 * 60 * 1000))
-            .expect("delete_old_logs_with_count failed");
-
-        assert_eq!(deleted, 1);
-        assert!(!tmp_path.exists(), "expected stale tmp log file to be deleted");
 
         let _ = fs::remove_dir_all(&base_dir);
     }

--- a/backend/crates/kalamdb-streams/src/time_bucket.rs
+++ b/backend/crates/kalamdb-streams/src/time_bucket.rs
@@ -1,6 +1,7 @@
 /// Time bucket granularity for log layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamTimeBucket {
+    Minute,
     Hour,
     Day,
     Week,
@@ -10,6 +11,7 @@ pub enum StreamTimeBucket {
 impl StreamTimeBucket {
     pub fn duration_ms(&self) -> u64 {
         match self {
+            StreamTimeBucket::Minute => 60 * 1000,
             StreamTimeBucket::Hour => 60 * 60 * 1000,
             StreamTimeBucket::Day => 24 * 60 * 60 * 1000,
             StreamTimeBucket::Week => 7 * 24 * 60 * 60 * 1000,
@@ -20,12 +22,16 @@ impl StreamTimeBucket {
 
 /// Resolve bucket granularity from TTL (seconds).
 pub fn bucket_for_ttl(ttl_seconds: u64) -> StreamTimeBucket {
+    const MINUTE: u64 = 60;
     const HOUR: u64 = 60 * 60;
     const DAY: u64 = 24 * HOUR;
     const WEEK: u64 = 7 * DAY;
     const MONTH: u64 = 30 * DAY;
+    const SHORT_TTL: u64 = 15 * MINUTE;
 
-    if ttl_seconds <= DAY {
+    if ttl_seconds <= SHORT_TTL {
+        StreamTimeBucket::Minute
+    } else if ttl_seconds <= DAY {
         StreamTimeBucket::Hour
     } else if ttl_seconds <= WEEK {
         StreamTimeBucket::Day
@@ -33,5 +39,25 @@ pub fn bucket_for_ttl(ttl_seconds: u64) -> StreamTimeBucket {
         StreamTimeBucket::Week
     } else {
         StreamTimeBucket::Month
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bucket_for_ttl, StreamTimeBucket};
+
+    #[test]
+    fn test_short_ttl_uses_minute_buckets() {
+        assert_eq!(bucket_for_ttl(10), StreamTimeBucket::Minute);
+        assert_eq!(bucket_for_ttl(30), StreamTimeBucket::Minute);
+        assert_eq!(bucket_for_ttl(15 * 60), StreamTimeBucket::Minute);
+    }
+
+    #[test]
+    fn test_longer_ttl_uses_coarser_buckets() {
+        assert_eq!(bucket_for_ttl(16 * 60), StreamTimeBucket::Hour);
+        assert_eq!(bucket_for_ttl(2 * 24 * 60 * 60), StreamTimeBucket::Day);
+        assert_eq!(bucket_for_ttl(10 * 24 * 60 * 60), StreamTimeBucket::Week);
+        assert_eq!(bucket_for_ttl(45 * 24 * 60 * 60), StreamTimeBucket::Month);
     }
 }

--- a/backend/crates/kalamdb-streams/src/utils.rs
+++ b/backend/crates/kalamdb-streams/src/utils.rs
@@ -5,18 +5,6 @@ use std::{
 
 use crate::error::{Result, StreamLogError};
 
-pub(crate) fn parse_log_window(path: &Path) -> Option<u64> {
-    let file_name = path.file_name()?.to_string_lossy();
-    let trimmed = file_name.strip_suffix(".log")?;
-    trimmed.parse::<u64>().ok()
-}
-
-pub(crate) fn parse_tmp_log_window(path: &Path) -> Option<u64> {
-    let file_name = path.file_name()?.to_string_lossy();
-    let trimmed = file_name.strip_suffix(".log.tmp")?;
-    trimmed.parse::<u64>().ok()
-}
-
 pub(crate) fn visit_dirs<F>(path: &Path, mut visitor: F) -> Result<bool>
 where
     F: FnMut(PathBuf) -> Result<bool>,
@@ -25,22 +13,6 @@ where
         let entry = entry.map_err(|e| StreamLogError::Io(e.to_string()))?;
         let path = entry.path();
         if path.is_dir() {
-            if !visitor(path)? {
-                return Ok(false);
-            }
-        }
-    }
-    Ok(true)
-}
-
-pub(crate) fn visit_files<F>(path: &Path, mut visitor: F) -> Result<bool>
-where
-    F: FnMut(PathBuf) -> Result<bool>,
-{
-    for entry in fs::read_dir(path).map_err(|e| StreamLogError::Io(e.to_string()))? {
-        let entry = entry.map_err(|e| StreamLogError::Io(e.to_string()))?;
-        let path = entry.path();
-        if path.is_file() {
             if !visitor(path)? {
                 return Ok(false);
             }

--- a/cli/tests/smoke.rs
+++ b/cli/tests/smoke.rs
@@ -51,6 +51,8 @@ mod smoke_test_as_user_chat_impersonation;
 mod smoke_test_as_user_impersonation;
 
 // Subscription tests
+#[path = "smoke/subscription/smoke_test_concurrent_subscriptions.rs"]
+mod smoke_test_concurrent_subscriptions;
 #[path = "smoke/subscription/smoke_test_shared_table_subscription.rs"]
 mod smoke_test_shared_table_subscription;
 #[path = "smoke/subscription/smoke_test_stream_subscription.rs"]
@@ -59,8 +61,6 @@ mod smoke_test_stream_subscription;
 mod smoke_test_subscription_advanced;
 #[path = "smoke/subscription/smoke_test_subscription_close.rs"]
 mod smoke_test_subscription_close;
-#[path = "smoke/subscription/smoke_test_concurrent_subscriptions.rs"]
-mod smoke_test_concurrent_subscriptions;
 #[path = "smoke/subscription/smoke_test_subscription_delete.rs"]
 mod smoke_test_subscription_delete;
 #[path = "smoke/subscription/smoke_test_subscription_delta_updates.rs"]

--- a/cli/tests/smoke/subscription/smoke_test_concurrent_subscriptions.rs
+++ b/cli/tests/smoke/subscription/smoke_test_concurrent_subscriptions.rs
@@ -177,7 +177,10 @@ fn smoke_test_concurrent_subscription_fanout() {
         );
     });
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP TABLE IF EXISTS {}", full_table_name_for_cleanup));
+    let _ = execute_sql_as_root_via_client(&format!(
+        "DROP TABLE IF EXISTS {}",
+        full_table_name_for_cleanup
+    ));
     let _ = execute_sql_as_root_via_client(&format!(
         "DROP NAMESPACE IF EXISTS {} CASCADE",
         namespace_for_cleanup
@@ -208,9 +211,8 @@ async fn wait_for_ack(subscription: &mut SubscriptionManager) -> Result<(), Stri
     let deadline = tokio::time::Instant::now() + ACK_TIMEOUT;
 
     while tokio::time::Instant::now() < deadline {
-        let remaining = deadline
-            .checked_duration_since(tokio::time::Instant::now())
-            .unwrap_or_default();
+        let remaining =
+            deadline.checked_duration_since(tokio::time::Instant::now()).unwrap_or_default();
 
         match tokio::time::timeout(remaining, subscription.next()).await {
             Ok(Some(Ok(ChangeEvent::Ack { .. }))) => return Ok(()),
@@ -232,9 +234,8 @@ async fn wait_for_insert_value(
     let deadline = tokio::time::Instant::now() + DELIVERY_TIMEOUT;
 
     while tokio::time::Instant::now() < deadline {
-        let remaining = deadline
-            .checked_duration_since(tokio::time::Instant::now())
-            .unwrap_or_default();
+        let remaining =
+            deadline.checked_duration_since(tokio::time::Instant::now()).unwrap_or_default();
 
         match tokio::time::timeout(remaining, subscription.next()).await {
             Ok(Some(Ok(ChangeEvent::Insert { rows, .. }))) => {
@@ -247,10 +248,7 @@ async fn wait_for_insert_value(
                 }
             },
             Ok(Some(Ok(ChangeEvent::Error { code, message, .. }))) => {
-                return Err(format!(
-                    "subscription {} returned error {}: {}",
-                    index, code, message
-                ));
+                return Err(format!("subscription {} returned error {}: {}", index, code, message));
             },
             Ok(Some(Ok(_))) => continue,
             Ok(Some(Err(error))) => {
@@ -296,14 +294,11 @@ async fn wait_for_live_query_count(prefix: &str, expected: usize, timeout: Durat
 
 async fn count_live_query_rows(prefix: &str) -> usize {
     let prefix = prefix.to_string();
-    let sql = format!(
-        "SELECT subscription_id FROM system.live LIMIT {}",
-        LIVE_QUERY_COUNT_QUERY_LIMIT
-    );
+    let sql =
+        format!("SELECT subscription_id FROM system.live LIMIT {}", LIVE_QUERY_COUNT_QUERY_LIMIT);
 
     tokio::task::spawn_blocking(move || {
-        execute_sql_as_root_via_client_json(&sql)
-            .map_err(|error| format!("{}", error))
+        execute_sql_as_root_via_client_json(&sql).map_err(|error| format!("{}", error))
     })
     .await
     .expect("spawn_blocking join failure")
@@ -326,12 +321,7 @@ async fn count_live_query_rows(prefix: &str) -> usize {
 
 fn sample_errors(errors: &[String]) -> String {
     let sample_count = errors.len().min(5);
-    let sample = errors
-        .iter()
-        .take(sample_count)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(" | ");
+    let sample = errors.iter().take(sample_count).cloned().collect::<Vec<_>>().join(" | ");
 
     if errors.len() > sample_count {
         format!("{} total errors; first {}: {}", errors.len(), sample_count, sample)

--- a/cli/tests/smoke/topics/topic_test_support.rs
+++ b/cli/tests/smoke/topics/topic_test_support.rs
@@ -112,6 +112,26 @@ pub fn is_retryable_consumer_poll_error(message: &str) -> bool {
         || normalized.contains("401")
 }
 
+async fn commit_processed_batch(
+    consumer: &mut TopicConsumer,
+    idle_sleep: Duration,
+    deadline: Instant,
+) {
+    loop {
+        match consumer.commit_sync().await {
+            Ok(_) => return,
+            Err(err) => {
+                let message = err.to_string();
+                if is_retryable_consumer_poll_error(&message) && Instant::now() < deadline {
+                    tokio::time::sleep(idle_sleep).await;
+                    continue;
+                }
+                panic!("topic consumer commit error: {}", message);
+            },
+        }
+    }
+}
+
 pub async fn build_test_consumer(
     topic: &str,
     group_id: &str,
@@ -176,7 +196,7 @@ pub async fn poll_unique_offsets_until(
                 }
 
                 if config.commit_each_batch {
-                    let _ = consumer.commit_sync().await;
+                    commit_processed_batch(consumer, config.idle_sleep, deadline).await;
                 }
             },
             Err(err) => {

--- a/docs/architecture/stream-storage.md
+++ b/docs/architecture/stream-storage.md
@@ -1,0 +1,39 @@
+# Stream Storage Architecture
+
+Stream tables are append-heavy, TTL-bound tables. Their durable production path is the file-backed stream log in `kalamdb-streams`; the in-memory backend remains for tests and explicitly ephemeral harnesses.
+
+## File Layout
+
+New file-backed stream rows are written to time-window directories directly under the stream base path:
+
+```text
+<stream_base>/w<window_start_ms>-<duration_ms>/<shard>/<user_id>.log
+```
+
+The window start and duration are encoded in the directory name so TTL eviction can decide whether a segment is expired without opening or deserializing row files. Rows remain user-scoped below each shard folder, preserving the existing stream isolation model and keeping active writers distributed across shard/user paths.
+
+## Bucket Sizing
+
+Bucket granularity is derived from `TTL_SECONDS`:
+
+- `<= 15 minutes`: minute windows
+- `<= 1 day`: hour windows
+- `<= 1 week`: day windows
+- `<= 30 days`: week windows
+- longer TTLs: month windows
+
+Short-lived streams use minute windows so cleanup latency stays close to the retention period instead of waiting for an hour-sized immutable file to age out. Longer TTLs use coarser windows to avoid creating too many small files.
+
+## Write Path
+
+Each stream record is appended as a length-prefixed flexbuffers frame. Writers are cached per segment path, use 64 KiB buffered writes, and are capped at 256 open segment writers per stream store. Old writers are flushed and closed when the cache exceeds the cap. The stream log does not call `fsync` on each append; stream rows are ephemeral and rely on the OS page cache for writeback.
+
+## Cleanup Path
+
+The stream eviction job computes a TTL cutoff and calls into the live `StreamTableStore`. File-backed cleanup removes whole expired window directories when `window_end <= cutoff`, closing any cached writer under the directory first. This makes normal retention a directory unlink operation rather than a row scan or per-user file walk.
+
+`has_logs_before()` checks the current window directories and returns as soon as it finds an expired window, avoiding a full file scan during job pre-validation. The job executor runs pre-validation scans and cleanup on Tokio's blocking pool so filesystem traversal and directory removal do not pin async worker threads.
+
+## Read Path
+
+Range and latest reads list a user's current window files, filter by window overlap, then read only candidate files.

--- a/nextest.toml
+++ b/nextest.toml
@@ -9,6 +9,33 @@ test-threads = 15
 # concurrency budget.
 stateful-heavy = { max-threads = 1 }
 proxied-reconnect = { max-threads = 2 }
+# Each OIDC e2e test spawns a fresh KalamDB server subprocess (debug binary).
+# Running all five concurrently causes RocksDB init / file-I/O contention that
+# pushes every server startup near the 30-second wait_for_auth_status deadline.
+# Allowing at most two at a time gives each server enough CPU and I/O headroom
+# to start in ~5-10 s instead of ~25-30 s, dropping per-test time well below
+# the 60-second SLOW threshold.
+oidc-fresh-server = { max-threads = 2 }
+
+[[profile.default.overrides]]
+filter = 'test(oidc_cli_dex_bearer_token_works_with_fresh_server)'
+test-group = "oidc-fresh-server"
+
+[[profile.default.overrides]]
+filter = 'test(oidc_cli_browser_login_with_dex_works_and_auto_provisions_user)'
+test-group = "oidc-fresh-server"
+
+[[profile.default.overrides]]
+filter = 'test(oidc_cli_headless_direct_device_login_works)'
+test-group = "oidc-fresh-server"
+
+[[profile.default.overrides]]
+filter = 'test(oidc_cli_headless_direct_device_login_with_local_dex_works)'
+test-group = "oidc-fresh-server"
+
+[[profile.default.overrides]]
+filter = 'test(oidc_cli_headless_brokered_device_login_works)'
+test-group = "oidc-fresh-server"
 
 # [[profile.default.overrides]]
 # filter = 'test(test_scenario_08_subscription_reconnect)'


### PR DESCRIPTION
Rework file-backed stream storage and eviction to use time-window directories and per-user .log files. Introduces window dirs named w<start>-<duration>, functions to parse and manage window dirs, and directory-level deletion of expired windows (closing cached writers first) to make eviction an unlink operation rather than per-file scans. Add minute-granularity buckets for short TTLs and tests for bucket selection. Move expensive filesystem checks in StreamEvictionExecutor onto Tokio's blocking pool to avoid pinning async workers. Update file-store helpers: collect/scan log files by window, list/collect user ids, close segments under directories, and simplify traversal utilities. Add numerous tests (including file-backed eviction), add ntest dev-dependency and timeouts for async tests, and small fixes: serde aliasing + unit tests for AuthType and Role, minor CLI test refactors, remove stray whitespace in observability, and add architecture docs and nextest profile overrides for OIDC tests.
