### PR TITLE
Add observability & TableCompression enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,6 +4512,7 @@ dependencies = [
  "flatbuffers",
  "flexbuffers",
  "hex",
+ "kalamdb-observability",
  "log",
  "nanoid",
  "once_cell",
@@ -4762,12 +4763,13 @@ dependencies = [
 name = "kalamdb-handlers-stream"
 version = "0.5.1-beta.2"
 dependencies = [
+ "arrow",
  "chrono",
- "datafusion",
  "kalamdb-commons",
  "kalamdb-core",
  "kalamdb-dialect",
  "kalamdb-handlers-support",
+ "kalamdb-observability",
  "kalamdb-system",
  "kalamdb-tables",
  "log",
@@ -4786,6 +4788,7 @@ dependencies = [
  "kalamdb-system",
  "log",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 
@@ -4845,6 +4848,7 @@ dependencies = [
  "datafusion-common",
  "kalamdb-commons",
  "kalamdb-dialect",
+ "kalamdb-observability",
  "kalamdb-publisher",
  "kalamdb-row-filter",
  "kalamdb-session",
@@ -4879,6 +4883,7 @@ dependencies = [
  "log",
  "num_cpus",
  "sysinfo",
+ "tracing",
 ]
 
 [[package]]
@@ -4925,6 +4930,7 @@ dependencies = [
  "dashmap 6.2.1",
  "datafusion-common",
  "kalamdb-commons",
+ "kalamdb-observability",
  "kalamdb-row-filter",
  "kalamdb-store",
  "kalamdb-system",
@@ -5088,6 +5094,7 @@ dependencies = [
  "datafusion",
  "kalamdb-commons",
  "kalamdb-configs",
+ "kalamdb-observability",
  "kalamdb-sharding",
  "kalamdb-system",
  "log",
@@ -5150,6 +5157,7 @@ dependencies = [
  "kalamdb-datafusion-sources",
  "kalamdb-filestore",
  "kalamdb-macros",
+ "kalamdb-observability",
  "kalamdb-session",
  "kalamdb-session-datafusion",
  "kalamdb-sharding",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -73,9 +73,10 @@ num_cpus = { workspace = true }
 libc = { workspace = true }
 
 [features]
-default = ["embedded-ui", "mimalloc"]
+default = ["embedded-ui", "mimalloc", "traceability"]
 mimalloc = ["dep:mimalloc", "kalamdb-core/mimalloc"]
 embedded-ui = ["kalamdb-api/embedded-ui"]
+traceability = ["kalamdb-core/traceability", "kalamdb-observability/traceability"]
 otel = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
 # End-to-end tests that require a full test server instance
 e2e-tests = []

--- a/backend/crates/kalamdb-api/src/http/topics/consume.rs
+++ b/backend/crates/kalamdb-api/src/http/topics/consume.rs
@@ -11,6 +11,7 @@ use actix_web::{post, web, HttpResponse, Responder};
 use kalamdb_auth::AuthSessionExtractor;
 use kalamdb_commons::Role;
 use kalamdb_core::app_context::AppContext;
+use kalamdb_observability::track_pubsub_consumer;
 use kalamdb_session::AuthSession;
 
 use super::models::{
@@ -57,6 +58,8 @@ pub async fn consume_handler(
             "Topic consumption requires service, dba, or system role",
         ));
     }
+
+    let _consumer_guard = track_pubsub_consumer();
 
     let topic_id = &body.topic_id;
     let group_id = body.group_id.as_ref();

--- a/backend/crates/kalamdb-commons/Cargo.toml
+++ b/backend/crates/kalamdb-commons/Cargo.toml
@@ -33,6 +33,7 @@ rmp-serde = { workspace = true, optional = true }
 rmp = { workspace = true, optional = true }
 nanoid = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
+kalamdb-observability = { path = "../kalamdb-observability", default-features = false }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -77,6 +78,7 @@ arrow-utils = [
 	]
 websocket-auth = ["serde"]
 msgpack = ["serde", "dep:rmp", "dep:rmp-serde"]
+traceability = ["kalamdb-observability/traceability"]
 # Full feature set including Arrow/DataFusion-backed utilities (for server use)
 full = [
 	"serde",

--- a/backend/crates/kalamdb-commons/src/conversions/arrow_json_conversion.rs
+++ b/backend/crates/kalamdb-commons/src/conversions/arrow_json_conversion.rs
@@ -54,12 +54,11 @@ type ArrayRef = Arc<dyn Array>;
 /// schema column is present and correctly typed so downstream constraint validation can see
 /// omitted columns instead of having them silently materialized to placeholder values.
 pub fn coerce_rows(rows: Vec<Row>, schema: &SchemaRef) -> Result<Vec<Row>, String> {
-    let _span = tracing::info_span!(
+    let _span = kalamdb_observability::kdb_debug_span_entered!(
         "coerce_rows",
         row_count = rows.len(),
         num_fields = schema.fields().len()
-    )
-    .entered();
+    );
     let typed_nulls = get_typed_nulls(schema);
 
     rows.into_iter()

--- a/backend/crates/kalamdb-commons/src/models/schemas/mod.rs
+++ b/backend/crates/kalamdb-commons/src/models/schemas/mod.rs
@@ -102,6 +102,7 @@ pub use table_access::TableAccess;
 pub use table_definition::TableDefinition;
 pub use table_name::TableName;
 pub use table_options::{
-    SharedTableOptions, StreamTableOptions, SystemTableOptions, TableOptions, UserTableOptions,
+    SharedTableOptions, StreamTableOptions, SystemTableOptions, TableCompression, TableOptions,
+    UserTableOptions,
 };
 pub use table_type::TableType;

--- a/backend/crates/kalamdb-commons/src/models/schemas/table_definition.rs
+++ b/backend/crates/kalamdb-commons/src/models/schemas/table_definition.rs
@@ -679,7 +679,6 @@ mod tests {
             ttl_seconds: 1800,
             eviction_strategy: "size_based".to_string(),
             max_stream_size_bytes: 1_000_000_000,
-            compression: "lz4".to_string(),
         });
 
         table.set_options(custom_opts);

--- a/backend/crates/kalamdb-commons/src/models/schemas/table_options.rs
+++ b/backend/crates/kalamdb-commons/src/models/schemas/table_options.rs
@@ -1,8 +1,89 @@
 //! Type-safe table options for different table types
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, str::FromStr};
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{schemas::policy::FlushPolicy, StorageId, TableAccess};
+
+/// Compression algorithms supported by KalamDB's Parquet cold-storage writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TableCompression {
+    None,
+    #[default]
+    Snappy,
+    Zstd,
+}
+
+impl TableCompression {
+    pub const SUPPORTED_VALUES: &'static str = "none, snappy, zstd";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            TableCompression::None => "none",
+            TableCompression::Snappy => "snappy",
+            TableCompression::Zstd => "zstd",
+        }
+    }
+}
+
+impl fmt::Display for TableCompression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for TableCompression {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TableCompression {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TableCompressionVisitor;
+
+        impl de::Visitor<'_> for TableCompressionVisitor {
+            type Value = TableCompression;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a supported table compression: none, snappy, or zstd")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                value.parse().map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(TableCompressionVisitor)
+    }
+}
+
+impl FromStr for TableCompression {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "none" => Ok(TableCompression::None),
+            "snappy" => Ok(TableCompression::Snappy),
+            "zstd" => Ok(TableCompression::Zstd),
+            other => Err(format!(
+                "Invalid COMPRESSION '{}'. Supported: {}",
+                other,
+                TableCompression::SUPPORTED_VALUES
+            )),
+        }
+    }
+}
 
 /// **Q: How does per-user storage assignment work with use_user_storage option?** → A: Lookup
 /// chain: table.use_user_storage=true → check user.storage_mode → if "region" use user.storage_id,
@@ -25,10 +106,9 @@ pub struct UserTableOptions {
     /// Flush policy (e.g. time-based, size-based or both)
     pub flush_policy: Option<FlushPolicy>,
 
-    /// Compression algorithm (none, snappy, lz4, zstd)
-    /// TODO: Make this an enum
+    /// Compression algorithm for Parquet cold-storage files.
     #[serde(default = "default_compression")]
-    pub compression: String,
+    pub compression: TableCompression,
 }
 
 /// Table options for SHARED tables
@@ -41,10 +121,9 @@ pub struct SharedTableOptions {
 
     pub flush_policy: Option<FlushPolicy>,
 
-    /// Compression algorithm (none, snappy, lz4, zstd)
-    /// TODO: Make this an enum
+    /// Compression algorithm for Parquet cold-storage files.
     #[serde(default = "default_compression")]
-    pub compression: String,
+    pub compression: TableCompression,
 }
 
 /// Table options for STREAM tables
@@ -60,10 +139,6 @@ pub struct StreamTableOptions {
     /// Maximum stream size in bytes (0 = unlimited)
     #[serde(default)]
     pub max_stream_size_bytes: u64,
-
-    /// Compression algorithm (none, snappy, lz4, zstd)
-    #[serde(default = "default_compression")]
-    pub compression: String,
 }
 
 /// Table options for SYSTEM tables
@@ -208,13 +283,21 @@ impl TableOptions {
         TableOptions::System(SystemTableOptions::default())
     }
 
-    /// Get the compression setting (common across all types)
+    /// Get the table-level Parquet compression setting when applicable.
     pub fn compression(&self) -> &str {
         match self {
-            TableOptions::User(opts) => &opts.compression,
-            TableOptions::Shared(opts) => &opts.compression,
-            TableOptions::Stream(opts) => &opts.compression,
-            TableOptions::System(_) => "none", // System tables don't use compression
+            TableOptions::User(opts) => opts.compression.as_str(),
+            TableOptions::Shared(opts) => opts.compression.as_str(),
+            TableOptions::Stream(_) | TableOptions::System(_) => "none",
+        }
+    }
+
+    /// Get the configured Parquet compression codec for table types that write cold segments.
+    pub fn parquet_compression(&self) -> TableCompression {
+        match self {
+            TableOptions::User(opts) => opts.compression,
+            TableOptions::Shared(opts) => opts.compression,
+            TableOptions::Stream(_) | TableOptions::System(_) => TableCompression::None,
         }
     }
 
@@ -253,8 +336,8 @@ fn default_true() -> bool {
     true
 }
 
-fn default_compression() -> String {
-    "snappy".to_string()
+fn default_compression() -> TableCompression {
+    TableCompression::default()
 }
 
 fn default_system_cache_ttl() -> u64 {
@@ -293,7 +376,6 @@ impl Default for StreamTableOptions {
             ttl_seconds: 86400, // 24 hours default
             eviction_strategy: default_eviction_strategy(),
             max_stream_size_bytes: 0,
-            compression: default_compression(),
         }
     }
 }
@@ -317,7 +399,7 @@ mod tests {
     fn test_user_table_options_default() {
         let opts = UserTableOptions::default();
         assert!(opts.flush_policy.is_none());
-        assert_eq!(opts.compression, "snappy");
+        assert_eq!(opts.compression, TableCompression::Snappy);
     }
 
     #[test]
@@ -325,7 +407,7 @@ mod tests {
         let opts = SharedTableOptions::default();
         assert_eq!(opts.access_level, Some(TableAccess::Private));
         assert!(opts.flush_policy.is_none());
-        assert_eq!(opts.compression, "snappy");
+        assert_eq!(opts.compression, TableCompression::Snappy);
     }
 
     #[test]
@@ -334,7 +416,6 @@ mod tests {
         assert_eq!(opts.ttl_seconds, 86400);
         assert_eq!(opts.eviction_strategy, "time_based");
         assert_eq!(opts.max_stream_size_bytes, 0);
-        assert_eq!(opts.compression, "snappy");
     }
 
     #[test]
@@ -369,7 +450,7 @@ mod tests {
     fn test_compression_getter() {
         assert_eq!(TableOptions::user().compression(), "snappy");
         assert_eq!(TableOptions::shared().compression(), "snappy");
-        assert_eq!(TableOptions::stream(3600).compression(), "snappy");
+        assert_eq!(TableOptions::stream(3600).compression(), "none");
         assert_eq!(TableOptions::system().compression(), "none");
     }
 
@@ -404,14 +485,37 @@ mod tests {
             ttl_seconds: 1800,
             eviction_strategy: "size_based".to_string(),
             max_stream_size_bytes: 1_000_000_000,
-            compression: "lz4".to_string(),
         });
 
-        assert_eq!(custom_stream.compression(), "lz4");
+        assert_eq!(custom_stream.compression(), "none");
         if let TableOptions::Stream(opts) = custom_stream {
             assert_eq!(opts.ttl_seconds, 1800);
             assert_eq!(opts.eviction_strategy, "size_based");
             assert_eq!(opts.max_stream_size_bytes, 1_000_000_000);
         }
+    }
+
+    #[test]
+    fn test_table_compression_supported_values() {
+        assert_eq!("none".parse::<TableCompression>().unwrap(), TableCompression::None);
+        assert_eq!("snappy".parse::<TableCompression>().unwrap(), TableCompression::Snappy);
+        assert_eq!("ZSTD".parse::<TableCompression>().unwrap(), TableCompression::Zstd);
+        assert!("lz4".parse::<TableCompression>().is_err());
+    }
+
+    #[test]
+    fn test_table_compression_serializes_as_lowercase_string() {
+        let json = serde_json::to_string(&TableCompression::Zstd).unwrap();
+        assert_eq!(json, "\"zstd\"");
+        let decoded: TableCompression = serde_json::from_str("\"snappy\"").unwrap();
+        assert_eq!(decoded, TableCompression::Snappy);
+    }
+
+    #[test]
+    fn test_table_compression_decodes_persisted_string_shape() {
+        let bytes = flexbuffers::to_vec("zstd").unwrap();
+        let decoded: TableCompression = flexbuffers::from_slice(&bytes).unwrap();
+
+        assert_eq!(decoded, TableCompression::Zstd);
     }
 }

--- a/backend/crates/kalamdb-commons/src/serialization/row_codec.rs
+++ b/backend/crates/kalamdb-commons/src/serialization/row_codec.rs
@@ -731,7 +731,10 @@ fn batch_encode_user_table_rows_iter<'a, I>(rows: I, row_count: usize) -> Result
 where
     I: IntoIterator<Item = &'a UserTableRow>,
 {
-    let _span = tracing::info_span!("batch_encode_user_table_rows", count = row_count).entered();
+    let _span = kalamdb_observability::kdb_debug_span_entered!(
+        "batch_encode_user_table_rows",
+        count = row_count
+    );
     let mut results = Vec::with_capacity(row_count);
     // Reuse inner builder across rows — reset() keeps the allocated capacity
     let mut inner_builder = flatbuffers::FlatBufferBuilder::with_capacity(512);
@@ -767,7 +770,10 @@ where
 
 /// Batch-encode multiple shared table rows, reusing internal FlatBufferBuilders.
 pub fn batch_encode_shared_table_rows(rows: &[(SeqId, u64, bool, &Row)]) -> Result<Vec<Vec<u8>>> {
-    let _span = tracing::info_span!("batch_encode_shared_table_rows", count = rows.len()).entered();
+    let _span = kalamdb_observability::kdb_debug_span_entered!(
+        "batch_encode_shared_table_rows",
+        count = rows.len()
+    );
     let mut results = Vec::with_capacity(rows.len());
     let mut inner_builder = flatbuffers::FlatBufferBuilder::with_capacity(512);
 

--- a/backend/crates/kalamdb-core/Cargo.toml
+++ b/backend/crates/kalamdb-core/Cargo.toml
@@ -97,6 +97,13 @@ expensive_tests = []
 # Expose test helpers to other crates' test code (dev-dependencies)
 test-helpers = ["kalamdb-live/test-helpers"]
 mimalloc = ["kalamdb-observability/mimalloc", "kalamdb-raft/mimalloc"]
+traceability = [
+    "kalamdb-commons/traceability",
+    "kalamdb-filestore/traceability",
+    "kalamdb-observability/traceability",
+    "kalamdb-store/traceability",
+    "kalamdb-tables/traceability",
+]
 
 [lib]
 doctest = false

--- a/backend/crates/kalamdb-core/src/applier/executor/dml.rs
+++ b/backend/crates/kalamdb-core/src/applier/executor/dml.rs
@@ -607,18 +607,17 @@ impl DmlExecutor {
                             ))
                         })?;
 
-                    provider
-                        .validate_insert_batch_rows(
-                            user_id,
-                            mutations.iter().map(|mutation| &mutation.payload),
-                        )
-                        .await
-                        .map_err(|error| {
+                    let batch_rows: Vec<&Row> =
+                        mutations.iter().map(|mutation| &mutation.payload).collect();
+
+                    provider.validate_insert_batch_rows(user_id, batch_rows).await.map_err(
+                        |error| {
                             ApplierError::Execution(format!(
                                 "Failed to insert batch row: {}",
                                 error
                             ))
-                        })?;
+                        },
+                    )?;
 
                     return Ok(());
                 }

--- a/backend/crates/kalamdb-core/src/applier/raft/mod.rs
+++ b/backend/crates/kalamdb-core/src/applier/raft/mod.rs
@@ -11,6 +11,7 @@
 mod provider_meta_applier;
 mod provider_shared_data_applier;
 mod provider_user_data_applier;
+mod utils;
 
 pub use provider_meta_applier::ProviderMetaApplier;
 pub use provider_shared_data_applier::ProviderSharedDataApplier;

--- a/backend/crates/kalamdb-core/src/applier/raft/provider_meta_applier.rs
+++ b/backend/crates/kalamdb-core/src/applier/raft/provider_meta_applier.rs
@@ -21,6 +21,8 @@ use crate::{
     applier::{executor::CommandExecutorImpl, ApplierError},
 };
 
+use super::utils::run_blocking_raft;
+
 /// Unified applier that persists all metadata operations to system tables
 ///
 /// This is used by the Raft state machine on follower nodes to apply
@@ -245,7 +247,7 @@ impl MetaApplier for ProviderMetaApplier {
 
         let app_context = self.app_context.clone();
         let job = job.clone();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             app_context
                 .system_tables()
                 .jobs()
@@ -253,7 +255,6 @@ impl MetaApplier for ProviderMetaApplier {
                 .map_err(|e| RaftError::Internal(format!("Failed to create job: {}", e)))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 
     async fn create_job_node(
@@ -275,15 +276,14 @@ impl MetaApplier for ProviderMetaApplier {
         };
 
         let app_context = self.app_context.clone();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             app_context
                 .system_tables()
                 .job_nodes()
                 .create_job_node(job_node)
                 .map_err(|e| RaftError::Internal(format!("Failed to create job_node: {}", e)))
         })
-        .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))??;
+        .await?;
 
         // Awake the job on THIS node for immediate execution
         // This provides instant dispatch rather than relying on polling
@@ -303,15 +303,14 @@ impl MetaApplier for ProviderMetaApplier {
     ) -> Result<String, RaftError> {
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
-        let node = tokio::task::spawn_blocking(move || {
+        let node = run_blocking_raft(move || {
             app_context
                 .system_tables()
                 .job_nodes()
                 .get_job_node(&job_id, &node_id)
                 .map_err(|e| RaftError::Internal(format!("Failed to get job_node: {}", e)))
         })
-        .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))??;
+        .await?;
 
         if let Some(mut node) = node {
             node.status = JobStatus::Running;
@@ -341,15 +340,14 @@ impl MetaApplier for ProviderMetaApplier {
     ) -> Result<String, RaftError> {
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
-        let node = tokio::task::spawn_blocking(move || {
+        let node = run_blocking_raft(move || {
             app_context
                 .system_tables()
                 .job_nodes()
                 .get_job_node(&job_id, &node_id)
                 .map_err(|e| RaftError::Internal(format!("Failed to get job_node: {}", e)))
         })
-        .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))??;
+        .await?;
 
         if let Some(mut node) = node {
             node.status = status;
@@ -388,7 +386,7 @@ impl MetaApplier for ProviderMetaApplier {
 
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             if let Some(mut job) = app_context
                 .system_tables()
                 .jobs()
@@ -420,7 +418,6 @@ impl MetaApplier for ProviderMetaApplier {
             Err(RaftError::Internal(format!("Job {} not found for claiming", job_id)))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 
     async fn update_job_status(
@@ -433,7 +430,7 @@ impl MetaApplier for ProviderMetaApplier {
 
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             if let Some(mut job) = app_context
                 .system_tables()
                 .jobs()
@@ -469,7 +466,6 @@ impl MetaApplier for ProviderMetaApplier {
             Ok(format!("Job {} not found for status update", job_id))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 
     async fn complete_job(
@@ -483,7 +479,7 @@ impl MetaApplier for ProviderMetaApplier {
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
         let result = result.map(String::from);
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             if let Some(mut job) = app_context
                 .system_tables()
                 .jobs()
@@ -513,7 +509,6 @@ impl MetaApplier for ProviderMetaApplier {
             Ok(format!("Job {} not found for completion", job_id))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 
     async fn fail_job(
@@ -527,7 +522,7 @@ impl MetaApplier for ProviderMetaApplier {
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
         let error_message = error_message.to_string();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             if let Some(mut job) = app_context
                 .system_tables()
                 .jobs()
@@ -555,7 +550,6 @@ impl MetaApplier for ProviderMetaApplier {
             Ok(format!("Job {} not found for failure", job_id))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 
     async fn release_job(
@@ -569,7 +563,7 @@ impl MetaApplier for ProviderMetaApplier {
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
         let reason = reason.to_string();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             if let Some(mut job) = app_context
                 .system_tables()
                 .jobs()
@@ -594,7 +588,6 @@ impl MetaApplier for ProviderMetaApplier {
             Ok(format!("Job {} not found for release", job_id))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 
     async fn cancel_job(
@@ -608,7 +601,7 @@ impl MetaApplier for ProviderMetaApplier {
         let app_context = self.app_context.clone();
         let job_id = job_id.clone();
         let reason = reason.to_string();
-        tokio::task::spawn_blocking(move || {
+        run_blocking_raft(move || {
             if let Some(mut job) = app_context
                 .system_tables()
                 .jobs()
@@ -633,6 +626,5 @@ impl MetaApplier for ProviderMetaApplier {
             Ok(format!("Job {} not found for cancellation", job_id))
         })
         .await
-        .map_err(|e| RaftError::Internal(format!("Task join error: {}", e)))?
     }
 }

--- a/backend/crates/kalamdb-core/src/applier/raft/utils.rs
+++ b/backend/crates/kalamdb-core/src/applier/raft/utils.rs
@@ -1,0 +1,11 @@
+use kalamdb_raft::RaftError;
+
+pub(super) async fn run_blocking_raft<T, F>(operation: F) -> Result<T, RaftError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, RaftError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|join_error| RaftError::Internal(format!("Task join error: {}", join_error)))?
+}

--- a/backend/crates/kalamdb-core/src/manifest/mod.rs
+++ b/backend/crates/kalamdb-core/src/manifest/mod.rs
@@ -182,5 +182,6 @@ fn small_segment_compaction_context(
         primary_key_field,
         cached.bloom_filter_columns().to_vec(),
         cached.indexed_columns().to_vec(),
+        cached.table.table_options.parquet_compression(),
     ))
 }

--- a/backend/crates/kalamdb-core/src/metrics/runtime.rs
+++ b/backend/crates/kalamdb-core/src/metrics/runtime.rs
@@ -120,6 +120,8 @@ impl SystemStatsSource for AppContextSystemStatsSource<'_> {
             topic_cache_topic_count: topic_cache_stats.topic_count,
             topic_cache_table_route_count: topic_cache_stats.table_route_count,
             topic_cache_total_routes: topic_cache_stats.total_routes,
+            topic_consumer_group_count: topic_cache_stats.consumer_group_count,
+            topic_consumer_partition_count: topic_cache_stats.consumer_partition_count,
             string_interner_unique_strings: kalamdb_commons::helpers::string_interner::stats()
                 .unique_strings,
         }

--- a/backend/crates/kalamdb-core/src/schema_registry/cached_table_data.rs
+++ b/backend/crates/kalamdb-core/src/schema_registry/cached_table_data.rs
@@ -179,8 +179,8 @@ impl CachedTableData {
     /// This is computed once when CachedTableData is created and reused for all
     /// flush operations. Returns (bloom_filter_columns, indexed_columns).
     ///
-    /// - bloom_filter_columns: PRIMARY KEY columns + _seq (for Parquet Bloom filters)
-    /// - indexed_columns: (column_id, column_name) pairs for row-group stats extraction
+    /// - bloom_filter_columns: PRIMARY KEY columns (for Parquet Bloom filters)
+    /// - indexed_columns: PRIMARY KEY columns + _seq for segment stats extraction
     fn compute_indexed_columns(table_def: &TableDefinition) -> (Vec<String>, Vec<(u64, String)>) {
         let mut bloom_filter_columns = Vec::new();
         let mut indexed_columns = Vec::new();
@@ -191,8 +191,7 @@ impl CachedTableData {
             indexed_columns.push((col.column_id, col.column_name.clone()));
         }
 
-        // Add _seq system column (always present for Bloom filters and stats)
-        bloom_filter_columns.push(SystemColumnNames::SEQ.to_string());
+        // Add _seq system column for range stats; Bloom filters are kept to PK columns.
         indexed_columns.push((0, SystemColumnNames::SEQ.to_string())); // _seq uses column_id 0
 
         (bloom_filter_columns, indexed_columns)
@@ -283,7 +282,7 @@ impl CachedTableData {
             })
     }
 
-    /// Get cached Bloom filter columns (PRIMARY KEY + _seq)
+    /// Get cached Bloom filter columns (PRIMARY KEY columns)
     ///
     /// These columns are computed once when the cache entry is created and
     /// remain constant for the lifetime of this schema version. Used for
@@ -367,5 +366,37 @@ mod tests {
 
         slot.set(third);
         assert_eq!(slot.get().unwrap().schema().field(0).name(), "third");
+    }
+
+    #[test]
+    fn cached_column_sets_keep_bloom_filters_to_primary_keys() {
+        use kalamdb_commons::{
+            models::{KalamDataType, NamespaceId, TableName},
+            schemas::{ColumnDefinition, TableOptions, TableType},
+        };
+
+        let table_def = TableDefinition::new(
+            NamespaceId::from("test"),
+            TableName::from("events"),
+            TableType::Shared,
+            vec![
+                ColumnDefinition::primary_key(1, "id", 1, KalamDataType::BigInt),
+                ColumnDefinition::simple(2, "name", 2, KalamDataType::Text),
+            ],
+            TableOptions::shared(),
+            None,
+        )
+        .expect("table definition");
+
+        let cached = CachedTableData::new(Arc::new(table_def));
+
+        assert_eq!(cached.bloom_filter_columns(), &["id".to_string()]);
+        assert_eq!(
+            cached.indexed_columns(),
+            &[
+                (1, "id".to_string()),
+                (0, SystemColumnNames::SEQ.to_string())
+            ]
+        );
     }
 }

--- a/backend/crates/kalamdb-core/src/sql/executor/sql_executor.rs
+++ b/backend/crates/kalamdb-core/src/sql/executor/sql_executor.rs
@@ -15,7 +15,6 @@ use kalamdb_commons::{
 };
 use kalamdb_sql::classifier::{SqlStatement, SqlStatementKind, StatementClassificationError};
 use kalamdb_transactions::{TransactionQueryContext, TransactionQueryExtension};
-use tracing::Instrument;
 use uuid::Uuid;
 
 use super::{PreparedExecutionStatement, SqlExecutor};
@@ -694,15 +693,8 @@ impl SqlExecutor {
         params: Vec<ScalarValue>,
     ) -> Result<ExecutionResult, KalamDbError> {
         let sql = metadata.sql.as_str();
-        let span = tracing::info_span!(
-            "sql.execute",
-            user_id = %exec_ctx.user_id().as_str(),
-            namespace = %exec_ctx.default_namespace().as_str(),
-            command = tracing::field::Empty,
-            rows = tracing::field::Empty,
-        );
-        // Enter the span for the entire execution
-        async {
+        kalamdb_observability::kdb_await_in_info_span!(
+            async {
             let query_start = Instant::now();
             let classified = match metadata.classified_statement.as_ref() {
                 Some(classified) => classified,
@@ -718,9 +710,11 @@ impl SqlExecutor {
                 },
             };
 
-            // Record the command kind in the span
-            let command_label = format!("{:?}", classified.kind());
-            tracing::Span::current().record("command", &command_label.as_str());
+            #[cfg(feature = "traceability")]
+            {
+                let command_label = format!("{:?}", classified.kind());
+                kalamdb_observability::kdb_record_current_span!("command", command_label.as_str());
+            }
             let query_kind = query_metric_kind(classified.kind());
             let observe_query_metrics = if matches!(exec_ctx.user_role(), Role::Dba | Role::System)
             {
@@ -885,7 +879,7 @@ impl SqlExecutor {
                 );
             }
 
-            // Record row count in the span
+            #[cfg(feature = "traceability")]
             if let Ok(ref res) = result {
                 let rows = match res {
                     ExecutionResult::Rows { row_count, .. } => *row_count,
@@ -894,13 +888,17 @@ impl SqlExecutor {
                     ExecutionResult::Deleted { rows_affected } => *rows_affected,
                     _ => 0,
                 };
-                tracing::Span::current().record("rows", rows);
+                kalamdb_observability::kdb_record_current_span!("rows", rows);
             }
 
             result
-        }
-        .instrument(span)
-        .await
+        },
+            "sql.execute",
+            user_id = %exec_ctx.user_id().as_str(),
+            namespace = %exec_ctx.default_namespace().as_str(),
+            command = tracing::field::Empty,
+            rows = tracing::field::Empty,
+        )
     }
 
     fn should_stage_autocommit_dml(
@@ -1004,11 +1002,12 @@ impl SqlExecutor {
         exec_ctx: &ExecutionContext,
     ) -> Result<(SessionContext, DataFrame), KalamDbError> {
         let session = self.create_session_with_transaction_context(exec_ctx)?;
+        #[cfg(feature = "traceability")]
         let plan_start = std::time::Instant::now();
 
         match session.sql(execution_sql).await {
             Ok(df) => {
-                tracing::debug!(
+                kalamdb_observability::kdb_debug!(
                     plan_ms = (plan_start.elapsed().as_micros() as f64 / 1000.0),
                     "sql.dml_plan"
                 );
@@ -1025,11 +1024,12 @@ impl SqlExecutor {
                 }
 
                 let retry_session = self.create_session_with_transaction_context(exec_ctx)?;
+                #[cfg(feature = "traceability")]
                 let retry_start = std::time::Instant::now();
                 let retry_df = retry_session.sql(execution_sql).await.map_err(|retry_error| {
                     self.log_sql_error(original_sql, exec_ctx, retry_error)
                 })?;
-                tracing::debug!(
+                kalamdb_observability::kdb_debug!(
                     plan_ms = (retry_start.elapsed().as_micros() as f64 / 1000.0),
                     reloaded_providers = true,
                     "sql.dml_plan"
@@ -1053,14 +1053,14 @@ impl SqlExecutor {
         replace_placeholders_in_plan(template_plan, params)
     }
 
-    #[tracing::instrument(
+    #[cfg_attr(feature = "traceability", tracing::instrument(
         name = "sql.dml_datafusion",
         skip_all,
         fields(
             dml_kind = %Self::dml_operation_name(dml_kind),
             rows_affected = tracing::field::Empty,
         )
-    )]
+    ))]
     async fn execute_dml_via_datafusion_inner(
         &self,
         sql: &str,
@@ -1127,15 +1127,16 @@ impl SqlExecutor {
             }
         };
 
+        #[cfg(feature = "traceability")]
         let collect_start = std::time::Instant::now();
         let batches = df.collect().await.map_err(Self::datafusion_to_execution_error)?;
-        tracing::debug!(
+        kalamdb_observability::kdb_debug!(
             collect_ms = collect_start.elapsed().as_secs_f64() * 1000.0,
             "sql.dml_collect"
         );
 
         let rows_affected = Self::extract_rows_affected(&batches)?;
-        tracing::Span::current().record("rows_affected", rows_affected);
+        kalamdb_observability::kdb_record_current_span!("rows_affected", rows_affected);
 
         Ok(match dml_kind {
             DmlKind::Insert => ExecutionResult::Inserted { rows_affected },
@@ -1145,11 +1146,11 @@ impl SqlExecutor {
     }
 
     /// Execute SELECT via DataFusion with per-user session
-    #[tracing::instrument(
+    #[cfg_attr(feature = "traceability", tracing::instrument(
         name = "sql.select_datafusion",
         skip_all,
         fields(row_count = tracing::field::Empty)
-    )]
+    ))]
     async fn execute_via_datafusion(
         &self,
         sql: &str,
@@ -1330,7 +1331,7 @@ impl SqlExecutor {
 
         // Calculate total row count
         let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
-        tracing::Span::current().record("row_count", row_count);
+        kalamdb_observability::kdb_record_current_span!("row_count", row_count);
 
         // Return batches with row count and schema (schema is needed when batches is empty)
         Ok(ExecutionResult::Rows {
@@ -1345,7 +1346,10 @@ impl SqlExecutor {
     /// These commands are passed directly to DataFusion without custom parsing.
     /// No plan caching is performed since these are diagnostic/config commands.
     /// Authorization is already checked in the classifier (admin only).
-    #[tracing::instrument(name = "sql.meta_command", skip_all)]
+    #[cfg_attr(
+        feature = "traceability",
+        tracing::instrument(name = "sql.meta_command", skip_all)
+    )]
     async fn execute_meta_command(
         &self,
         sql: &str,

--- a/backend/crates/kalamdb-dialect/src/ddl/alter_table.rs
+++ b/backend/crates/kalamdb-dialect/src/ddl/alter_table.rs
@@ -7,7 +7,7 @@
 
 use kalamdb_commons::{
     models::{datatypes::KalamDataType, NamespaceId, StorageId, TableAccess, TableName},
-    schemas::{policy::FlushPolicy, ColumnDefault},
+    schemas::{policy::FlushPolicy, ColumnDefault, TableCompression},
 };
 use kalamdb_system::VectorMetric;
 use once_cell::sync::Lazy;
@@ -76,7 +76,7 @@ pub struct TablePropertyUpdates {
     pub flush_policy: Option<Option<FlushPolicy>>,
     pub ttl_seconds: Option<u64>,
     pub access_level: Option<TableAccess>,
-    pub compression: Option<String>,
+    pub compression: Option<TableCompression>,
     pub eviction_strategy: Option<String>,
     pub max_stream_size_bytes: Option<u64>,
 }
@@ -676,15 +676,8 @@ fn parse_u64_property(value: &Expr, property_name: &str) -> DdlResult<u64> {
     expr_to_literal(value).parse().map_err(|_| format!("Invalid {}", property_name))
 }
 
-fn parse_compression_property(value: &Expr) -> DdlResult<String> {
-    let normalized = expr_to_literal(value).trim().to_ascii_lowercase();
-    match normalized.as_str() {
-        "none" | "snappy" | "lz4" | "zstd" => Ok(normalized),
-        _ => Err(format!(
-            "Invalid COMPRESSION '{}'. Supported: none, snappy, lz4, zstd",
-            normalized
-        )),
-    }
+fn parse_compression_property(value: &Expr) -> DdlResult<TableCompression> {
+    expr_to_literal(value).parse()
 }
 
 fn parse_eviction_strategy_property(value: &Expr) -> DdlResult<String> {
@@ -1023,7 +1016,7 @@ mod tests {
                 assert_eq!(updates.storage_id.unwrap().as_str(), "local-ssd");
                 assert_eq!(updates.use_user_storage, Some(true));
                 assert!(matches!(updates.flush_policy, Some(Some(FlushPolicy::RowLimit { .. }))));
-                assert_eq!(updates.compression.as_deref(), Some("zstd"));
+                assert_eq!(updates.compression, Some(TableCompression::Zstd));
             },
             _ => panic!("Expected SetTableOptions operation"),
         }
@@ -1032,7 +1025,7 @@ mod tests {
     #[test]
     fn test_parse_set_tblproperties_stream_options() {
         let stmt = AlterTableStatement::parse(
-            "ALTER TABLE events SET TBLPROPERTIES (TTL_SECONDS=7200, EVICTION_STRATEGY='hybrid', MAX_STREAM_SIZE_BYTES=1048576, COMPRESSION='lz4')",
+            "ALTER TABLE events SET TBLPROPERTIES (TTL_SECONDS=7200, EVICTION_STRATEGY='hybrid', MAX_STREAM_SIZE_BYTES=1048576)",
             &test_namespace(),
         )
         .unwrap();
@@ -1042,10 +1035,33 @@ mod tests {
                 assert_eq!(updates.ttl_seconds, Some(7200));
                 assert_eq!(updates.eviction_strategy.as_deref(), Some("hybrid"));
                 assert_eq!(updates.max_stream_size_bytes, Some(1_048_576));
-                assert_eq!(updates.compression.as_deref(), Some("lz4"));
+                assert_eq!(updates.compression, None);
             },
             _ => panic!("Expected SetTableOptions operation"),
         }
+    }
+
+    #[test]
+    fn test_parse_set_tblproperties_none_compression() {
+        let stmt = AlterTableStatement::parse(
+            "ALTER TABLE profiles SET TBLPROPERTIES (COMPRESSION='none')",
+            &test_namespace(),
+        )
+        .unwrap();
+
+        match stmt.operation {
+            ColumnOperation::SetTableOptions { updates } => {
+                assert_eq!(updates.compression, Some(TableCompression::None));
+            },
+            _ => panic!("Expected SetTableOptions operation"),
+        }
+    }
+
+    #[test]
+    fn test_parse_set_tblproperties_rejects_unsupported_compression() {
+        let sql = "ALTER TABLE events SET TBLPROPERTIES (COMPRESSION='lz4')";
+        let err = AlterTableStatement::parse(sql, &test_namespace()).unwrap_err();
+        assert!(err.contains("Supported: none, snappy, zstd"));
     }
 
     #[test]

--- a/backend/crates/kalamdb-dialect/src/ddl/create_table/parser.rs
+++ b/backend/crates/kalamdb-dialect/src/ddl/create_table/parser.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::{Field, Schema};
 use kalamdb_commons::{
     conversions::with_kalam_data_type_metadata,
     models::{datatypes::ToArrowType, NamespaceId, StorageId, TableAccess, TableName},
-    schemas::{policy::FlushPolicy, ColumnDefault, TableType},
+    schemas::{policy::FlushPolicy, ColumnDefault, TableCompression, TableType},
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -289,6 +289,11 @@ impl CreateTableStatement {
                         "FLUSH_POLICY is only supported for USER and SHARED tables".to_string()
                     );
                 }
+                if table_type == TableType::Stream && compression.is_some() {
+                    return Err(
+                        "COMPRESSION is only supported for USER and SHARED tables".to_string()
+                    );
+                }
                 if table_type != TableType::User && use_user_storage {
                     return Err("USE_USER_STORAGE is only supported for USER tables".to_string());
                 }
@@ -487,12 +492,8 @@ impl CreateTableStatement {
     }
 }
 
-fn parse_compression_option(value: &str) -> Result<String, String> {
-    let normalized = value.trim().to_ascii_lowercase();
-    match normalized.as_str() {
-        "none" | "snappy" | "lz4" | "zstd" => Ok(normalized),
-        _ => Err(format!("Invalid COMPRESSION '{}'. Supported: none, snappy, lz4, zstd", value)),
-    }
+fn parse_compression_option(value: &str) -> Result<TableCompression, String> {
+    value.parse()
 }
 
 fn parse_eviction_strategy_option(value: &str) -> Result<String, String> {
@@ -656,7 +657,7 @@ CREATE TABLE sales.user_profile (
         assert_eq!(stmt.storage_id.unwrap().as_str(), "local-ssd");
         assert!(stmt.use_user_storage);
         assert!(matches!(stmt.flush_policy, Some(FlushPolicy::RowLimit { .. })));
-        assert_eq!(stmt.compression.as_deref(), Some("zstd"));
+        assert_eq!(stmt.compression, Some(TableCompression::Zstd));
 
         let stream_sql = r#"
 CREATE TABLE sales.events (
@@ -666,8 +667,7 @@ CREATE TABLE sales.events (
     TYPE = 'STREAM',
     TTL_SECONDS = 3600,
     EVICTION_STRATEGY = 'hybrid',
-    MAX_STREAM_SIZE_BYTES = 1048576,
-    COMPRESSION = 'lz4'
+    MAX_STREAM_SIZE_BYTES = 1048576
 );
 "#;
         let stmt = CreateTableStatement::parse(stream_sql, DEFAULT_NS).unwrap();
@@ -675,7 +675,26 @@ CREATE TABLE sales.events (
         assert_eq!(stmt.ttl_seconds, Some(3600));
         assert_eq!(stmt.eviction_strategy.as_deref(), Some("hybrid"));
         assert_eq!(stmt.max_stream_size_bytes, Some(1_048_576));
-        assert_eq!(stmt.compression.as_deref(), Some("lz4"));
+        assert_eq!(stmt.compression, None);
+
+        let none_sql = "CREATE TABLE sales.raw (id BIGINT PRIMARY KEY) WITH (TYPE='SHARED', COMPRESSION='none')";
+        let stmt = CreateTableStatement::parse(none_sql, DEFAULT_NS).unwrap();
+        assert_eq!(stmt.table_type, TableType::Shared);
+        assert_eq!(stmt.compression, Some(TableCompression::None));
+    }
+
+    #[test]
+    fn create_table_rejects_unsupported_compression() {
+        let sql = "CREATE TABLE sales.bad_compression (id BIGINT PRIMARY KEY) WITH (TYPE='USER', COMPRESSION='lz4')";
+        let err = CreateTableStatement::parse(sql, DEFAULT_NS).unwrap_err();
+        assert!(err.contains("Supported: none, snappy, zstd"));
+    }
+
+    #[test]
+    fn create_table_rejects_stream_compression() {
+        let sql = "CREATE TABLE sales.bad_stream (id BIGINT PRIMARY KEY) WITH (TYPE='STREAM', TTL_SECONDS=60, COMPRESSION='snappy')";
+        let err = CreateTableStatement::parse(sql, DEFAULT_NS).unwrap_err();
+        assert!(err.contains("COMPRESSION is only supported for USER and SHARED tables"));
     }
 
     #[test]

--- a/backend/crates/kalamdb-dialect/src/ddl/create_table/types.rs
+++ b/backend/crates/kalamdb-dialect/src/ddl/create_table/types.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use arrow::datatypes::Schema;
 use kalamdb_commons::{
     models::{NamespaceId, StorageId, TableAccess, TableName},
-    schemas::{policy::FlushPolicy, ColumnDefault, TableType},
+    schemas::{policy::FlushPolicy, ColumnDefault, TableCompression, TableType},
 };
 
 /// Unified CREATE TABLE statement that works for USER, SHARED, and STREAM tables
@@ -31,8 +31,8 @@ pub struct CreateTableStatement {
     pub deleted_retention_hours: Option<u32>,
     /// TTL for stream tables in seconds (STREAM tables only)
     pub ttl_seconds: Option<u64>,
-    /// Compression algorithm (none, snappy, lz4, zstd)
-    pub compression: Option<String>,
+    /// Compression algorithm for Parquet cold-storage files.
+    pub compression: Option<TableCompression>,
     /// Stream eviction strategy (time_based, size_based, hybrid)
     pub eviction_strategy: Option<String>,
     /// Maximum stream size in bytes (0 = unlimited)

--- a/backend/crates/kalamdb-filestore/Cargo.toml
+++ b/backend/crates/kalamdb-filestore/Cargo.toml
@@ -76,6 +76,7 @@ default = ["cloud-aws"]
 cloud-aws = ["object_store/aws"]
 cloud-gcp = ["object_store/gcp"]
 cloud-azure = ["object_store/azure"]
+traceability = ["kalamdb-commons/traceability", "kalamdb-observability/traceability"]
 
 [dev-dependencies]
 once_cell = { workspace = true }

--- a/backend/crates/kalamdb-filestore/src/manifest/json.rs
+++ b/backend/crates/kalamdb-filestore/src/manifest/json.rs
@@ -40,20 +40,19 @@ pub fn write_manifest_json(
     user_id: Option<&UserId>,
     json_content: &str,
 ) -> Result<()> {
-    let span = tracing::info_span!(
+    let _span_guard = kalamdb_observability::kdb_debug_span_entered!(
         "manifest.write",
         table_type = ?table_type,
         table_id = %table_id,
         has_user_id = user_id.is_some(),
         bytes = json_content.len()
     );
-    let _span_guard = span.entered();
 
     let bytes = Bytes::from(json_content.to_string());
     storage_cached
         .put_sync(table_type, table_id, user_id, "manifest.json", bytes)
         .map(|_| {
-            tracing::debug!("Manifest write completed");
+            kalamdb_observability::kdb_debug!("Manifest write completed");
         })
 }
 

--- a/backend/crates/kalamdb-filestore/src/parquet/reader.rs
+++ b/backend/crates/kalamdb-filestore/src/parquet/reader.rs
@@ -5,9 +5,8 @@
 //!
 //! # Performance Features
 //!
-//! - **Column Projection**: Only read the columns you need, reducing I/O and memory
-//! - **Row Group Pruning via Bloom Filters**: Skip entire row groups where the bloom filter reports
-//!   a value is "definitely not present"
+//! - **Column Projection**: Pushes a Parquet projection mask so unneeded column chunks are not
+//!   read or decoded
 //! - **Streaming I/O**: All reads use `ParquetObjectReader` — reads only the footer eagerly and
 //!   fetches column chunks on demand via range requests (remote) or file seeks (local). No
 //!   full-file downloads.

--- a/backend/crates/kalamdb-filestore/src/parquet/writer.rs
+++ b/backend/crates/kalamdb-filestore/src/parquet/writer.rs
@@ -9,7 +9,7 @@ use arrow::{
 };
 use bytes::Bytes;
 use datafusion::arrow::compute::{self, SortOptions};
-use kalamdb_commons::constants::SystemColumnNames;
+use kalamdb_commons::{constants::SystemColumnNames, schemas::TableCompression};
 use parquet::{
     arrow::ArrowWriter,
     basic::{Compression, ZstdLevel},
@@ -28,24 +28,21 @@ pub struct ParquetWriteResult {
     pub size_bytes: u64,
 }
 
-/// Serialize Arrow RecordBatches to Parquet format in memory.
-pub(crate) fn serialize_to_parquet(
+pub(crate) fn serialize_to_parquet_with_compression(
     schema: SchemaRef,
     batches: Vec<RecordBatch>,
     bloom_filter_columns: Option<Vec<String>>,
+    compression: TableCompression,
 ) -> Result<Bytes> {
-    let row_count: u64 = batches.iter().map(|batch| batch.num_rows() as u64).sum();
-    let bloom_filter_count = bloom_filter_columns.as_ref().map_or(0, Vec::len);
-    let span = tracing::debug_span!(
+    let _span_guard = kalamdb_observability::kdb_debug_span_entered!(
         "parquet.serialize",
-        row_count = row_count,
-        bloom_filter_count = bloom_filter_count
+        row_count = batches.iter().map(|batch| batch.num_rows() as u64).sum::<u64>(),
+        bloom_filter_count = bloom_filter_columns.as_ref().map_or(0, Vec::len)
     );
-    let _span_guard = span.entered();
 
     let batches = sort_batches_by_seq(batches)?;
     let total_rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
-    let props = writer_properties(total_rows, bloom_filter_columns);
+    let props = writer_properties(total_rows, bloom_filter_columns, compression);
 
     // Write to in-memory buffer
     let mut buffer = Vec::with_capacity(PARQUET_INITIAL_BUFFER_BYTES);
@@ -60,7 +57,7 @@ pub(crate) fn serialize_to_parquet(
         writer.close().map_err(|e| FilestoreError::Parquet(e.to_string()))?;
     }
 
-    tracing::debug!(size_bytes = buffer.len(), "Parquet serialization completed");
+    kalamdb_observability::kdb_debug!(size_bytes = buffer.len(), "Parquet serialization completed");
     Ok(Bytes::from(buffer))
 }
 
@@ -70,11 +67,27 @@ pub(crate) fn serialize_to_parquet(
 /// keeping row materialization bounded to the channel capacity plus one Arrow batch.
 pub fn serialize_record_batch_receiver_to_parquet(
     schema: SchemaRef,
-    mut receiver: tokio::sync::mpsc::Receiver<Result<RecordBatch>>,
+    receiver: tokio::sync::mpsc::Receiver<Result<RecordBatch>>,
     bloom_filter_columns: Option<Vec<String>>,
     estimated_rows: u64,
 ) -> Result<Bytes> {
-    let props = writer_properties(estimated_rows, bloom_filter_columns);
+    serialize_record_batch_receiver_to_parquet_with_compression(
+        schema,
+        receiver,
+        bloom_filter_columns,
+        estimated_rows,
+        TableCompression::default(),
+    )
+}
+
+pub fn serialize_record_batch_receiver_to_parquet_with_compression(
+    schema: SchemaRef,
+    mut receiver: tokio::sync::mpsc::Receiver<Result<RecordBatch>>,
+    bloom_filter_columns: Option<Vec<String>>,
+    estimated_rows: u64,
+    compression: TableCompression,
+) -> Result<Bytes> {
+    let props = writer_properties(estimated_rows, bloom_filter_columns, compression);
     let mut buffer = Vec::with_capacity(PARQUET_INITIAL_BUFFER_BYTES);
     let mut rows_written = 0u64;
 
@@ -91,7 +104,7 @@ pub fn serialize_record_batch_receiver_to_parquet(
         writer.close().map_err(|e| FilestoreError::Parquet(e.to_string()))?;
     }
 
-    tracing::debug!(
+    kalamdb_observability::kdb_debug!(
         row_count = rows_written,
         size_bytes = buffer.len(),
         "Streaming Parquet serialization completed"
@@ -102,6 +115,7 @@ pub fn serialize_record_batch_receiver_to_parquet(
 fn writer_properties(
     row_count: u64,
     bloom_filter_columns: Option<Vec<String>>,
+    compression: TableCompression,
 ) -> WriterProperties {
     let bloom_ndv_estimate = row_count.max(1);
     let bloom_filter_columns = if row_count < MIN_ROWS_FOR_BLOOM_FILTERS {
@@ -111,7 +125,7 @@ fn writer_properties(
     };
 
     let mut props_builder = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(zstd_level()))
+        .set_compression(parquet_compression(compression))
         .set_max_row_group_row_count(Some(128 * 1024));
 
     if let Some(cols) = bloom_filter_columns {
@@ -124,6 +138,14 @@ fn writer_properties(
     }
 
     props_builder.build()
+}
+
+fn parquet_compression(compression: TableCompression) -> Compression {
+    match compression {
+        TableCompression::None => Compression::UNCOMPRESSED,
+        TableCompression::Snappy => Compression::SNAPPY,
+        TableCompression::Zstd => Compression::ZSTD(zstd_level()),
+    }
 }
 
 fn zstd_level() -> ZstdLevel {
@@ -201,10 +223,11 @@ fn is_sorted_by_seq(batch: &RecordBatch, seq_idx: usize) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{fs, sync::Arc};
 
     use arrow::array::StringArray;
     use kalamdb_commons::arrow_utils::{field_utf8, schema};
+    use parquet::file::reader::{FileReader, SerializedFileReader};
 
     use super::*;
 
@@ -221,9 +244,32 @@ mod tests {
     #[test]
     fn test_serialize_to_parquet() {
         let (schema, batches) = make_test_batch();
-        let bytes = serialize_to_parquet(schema, batches, None).unwrap();
+        let bytes =
+            serialize_to_parquet_with_compression(schema, batches, None, TableCompression::Snappy)
+                .unwrap();
         assert!(!bytes.is_empty());
         // Parquet magic number at start
         assert_eq!(&bytes[0..4], b"PAR1");
+    }
+
+    #[test]
+    fn test_supported_compressions_are_written_to_parquet_metadata() {
+        for (table_compression, expected) in [
+            (TableCompression::None, Compression::UNCOMPRESSED),
+            (TableCompression::Snappy, Compression::SNAPPY),
+            (TableCompression::Zstd, Compression::ZSTD(zstd_level())),
+        ] {
+            let (schema, batches) = make_test_batch();
+            let bytes =
+                serialize_to_parquet_with_compression(schema, batches, None, table_compression)
+                    .unwrap();
+            let temp_file = tempfile::NamedTempFile::new().unwrap();
+            fs::write(temp_file.path(), bytes).unwrap();
+
+            let file = fs::File::open(temp_file.path()).unwrap();
+            let reader = SerializedFileReader::new(file).unwrap();
+            let column = reader.metadata().row_group(0).column(0);
+            assert_eq!(column.compression(), expected);
+        }
     }
 }

--- a/backend/crates/kalamdb-filestore/src/registry/storage_cached.rs
+++ b/backend/crates/kalamdb-filestore/src/registry/storage_cached.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use kalamdb_commons::{
     models::{TableId, UserId},
-    schemas::TableType,
+    schemas::{TableCompression, TableType},
 };
 use kalamdb_system::{providers::storages::models::StorageType, Storage};
 use object_store::{path::Path as ObjectPath, ObjectStore, ObjectStoreExt};
@@ -24,7 +24,7 @@ use super::operations::{
 use crate::{
     core::runtime::run_blocking,
     error::{FilestoreError, Result},
-    parquet::writer::{serialize_to_parquet, ParquetWriteResult},
+    parquet::writer::{serialize_to_parquet_with_compression, ParquetWriteResult},
     paths::{PathResolver, TemplateResolver},
 };
 
@@ -420,7 +420,38 @@ impl StorageCached {
         batches: Vec<RecordBatch>,
         bloom_filter_columns: Option<Vec<String>>,
     ) -> Result<ParquetWriteResult> {
-        let parquet_bytes = serialize_to_parquet(schema, batches, bloom_filter_columns)?;
+        self.write_parquet_with_compression(
+            table_type,
+            table_id,
+            user_id,
+            filename,
+            schema,
+            batches,
+            bloom_filter_columns,
+            TableCompression::default(),
+        )
+        .await
+    }
+
+    /// Write `RecordBatch`es as Parquet using the table's configured compression.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn write_parquet_with_compression(
+        &self,
+        table_type: TableType,
+        table_id: &TableId,
+        user_id: Option<&UserId>,
+        filename: &str,
+        schema: SchemaRef,
+        batches: Vec<RecordBatch>,
+        bloom_filter_columns: Option<Vec<String>>,
+        compression: TableCompression,
+    ) -> Result<ParquetWriteResult> {
+        let parquet_bytes = serialize_to_parquet_with_compression(
+            schema,
+            batches,
+            bloom_filter_columns,
+            compression,
+        )?;
         let size_bytes = parquet_bytes.len() as u64;
         self.put(table_type, table_id, user_id, filename, parquet_bytes).await?;
         Ok(ParquetWriteResult { size_bytes })
@@ -574,6 +605,34 @@ impl StorageCached {
                 schema,
                 batches,
                 bloom_filter_columns,
+            )
+            .await
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn write_parquet_with_compression_sync(
+        &self,
+        table_type: TableType,
+        table_id: &TableId,
+        user_id: Option<&UserId>,
+        filename: &str,
+        schema: SchemaRef,
+        batches: Vec<RecordBatch>,
+        bloom_filter_columns: Option<Vec<String>>,
+        compression: TableCompression,
+    ) -> Result<ParquetWriteResult> {
+        let (tid, uid, f) = (table_id.clone(), user_id.cloned(), filename.to_string());
+        run_blocking(|| async {
+            self.write_parquet_with_compression(
+                table_type,
+                &tid,
+                uid.as_ref(),
+                &f,
+                schema,
+                batches,
+                bloom_filter_columns,
+                compression,
             )
             .await
         })

--- a/backend/crates/kalamdb-flush/src/compaction/small_segment.rs
+++ b/backend/crates/kalamdb-flush/src/compaction/small_segment.rs
@@ -13,8 +13,11 @@ use datafusion::arrow::{
 use datafusion::scalar::ScalarValue;
 use futures_util::TryStreamExt;
 use kalamdb_commons::{
-    arrow_utils::array_value_to_string, constants::SystemColumnNames,
-    models::rows::StoredScalarValue, schemas::TableType, TableId, UserId,
+    arrow_utils::array_value_to_string,
+    constants::SystemColumnNames,
+    models::rows::StoredScalarValue,
+    schemas::{TableCompression, TableType},
+    TableId, UserId,
 };
 use kalamdb_configs::FlushCompactionSettings;
 use kalamdb_filestore::StorageCached;
@@ -52,6 +55,7 @@ pub struct SmallSegmentCompactionContext {
     pub primary_key_field: String,
     pub bloom_filter_columns: Vec<String>,
     pub indexed_columns: Vec<(u64, String)>,
+    pub compression: TableCompression,
 }
 
 impl SmallSegmentCompactionContext {
@@ -65,6 +69,7 @@ impl SmallSegmentCompactionContext {
         primary_key_field: String,
         bloom_filter_columns: Vec<String>,
         indexed_columns: Vec<(u64, String)>,
+        compression: TableCompression,
     ) -> Self {
         Self {
             manifest_service,
@@ -75,6 +80,7 @@ impl SmallSegmentCompactionContext {
             primary_key_field,
             bloom_filter_columns,
             indexed_columns,
+            compression,
         }
     }
 
@@ -84,6 +90,7 @@ impl SmallSegmentCompactionContext {
             primary_key_field: self.primary_key_field.clone(),
             bloom_filter_columns: self.bloom_filter_columns.clone(),
             indexed_columns: self.indexed_columns.clone(),
+            compression: self.compression,
         }
     }
 }
@@ -93,6 +100,7 @@ struct CompactionSchemaContext {
     primary_key_field: String,
     bloom_filter_columns: Vec<String>,
     indexed_columns: Vec<(u64, String)>,
+    compression: TableCompression,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -557,12 +565,14 @@ async fn write_compacted_winners(
         tokio::sync::mpsc::channel::<kalamdb_filestore::Result<RecordBatch>>(2);
     let writer_schema = schema_context.schema.clone();
     let writer_bloom_columns = Some(schema_context.bloom_filter_columns.clone());
+    let writer_compression = schema_context.compression;
     let writer_handle = tokio::task::spawn_blocking(move || {
-        kalamdb_filestore::parquet::writer::serialize_record_batch_receiver_to_parquet(
+        kalamdb_filestore::parquet::writer::serialize_record_batch_receiver_to_parquet_with_compression(
             writer_schema,
             receiver,
             writer_bloom_columns,
             expected_output_rows,
+            writer_compression,
         )
     });
 

--- a/backend/crates/kalamdb-flush/src/flush/base.rs
+++ b/backend/crates/kalamdb-flush/src/flush/base.rs
@@ -21,7 +21,10 @@
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::SchemaRef;
-use kalamdb_commons::{schemas::TableType, TableId, UserId};
+use kalamdb_commons::{
+    schemas::{TableCompression, TableType},
+    TableId, UserId,
+};
 use kalamdb_filestore::StorageCached;
 use serde::{Deserialize, Serialize};
 
@@ -121,6 +124,7 @@ pub struct FlushTableMetadata {
     pub schema_version: u32,
     pub bloom_filter_columns: Vec<String>,
     pub indexed_columns: Vec<(u64, String)>,
+    pub compression: TableCompression,
 }
 
 impl FlushTableMetadata {
@@ -128,11 +132,13 @@ impl FlushTableMetadata {
         schema_version: u32,
         bloom_filter_columns: Vec<String>,
         indexed_columns: Vec<(u64, String)>,
+        compression: TableCompression,
     ) -> Self {
         Self {
             schema_version,
             bloom_filter_columns,
             indexed_columns,
+            compression,
         }
     }
 }

--- a/backend/crates/kalamdb-flush/src/flush/scope_writer.rs
+++ b/backend/crates/kalamdb-flush/src/flush/scope_writer.rs
@@ -117,7 +117,7 @@ impl<'a> FlushScopeWriter<'a> {
             );
             let result = self
                 .storage_cached
-                .write_parquet_sync(
+                .write_parquet_with_compression_sync(
                     self.table_type,
                     self.table_id,
                     user_id,
@@ -125,6 +125,7 @@ impl<'a> FlushScopeWriter<'a> {
                     self.schema.clone(),
                     vec![batch.clone()],
                     Some(self.metadata.bloom_filter_columns.clone()),
+                    self.metadata.compression,
                 )
                 .into_flush_error("Filestore error")?;
 

--- a/backend/crates/kalamdb-flush/src/flush/users.rs
+++ b/backend/crates/kalamdb-flush/src/flush/users.rs
@@ -26,7 +26,7 @@ use crate::{error::FlushResultExt, FlushError, FlushManifestHelper, ManifestServ
 /// User table flush job
 ///
 /// Flushes user table data to Parquet files. Each user's data is written to a
-/// separate Parquet file for RLS isolation. Uses Bloom filters on PRIMARY KEY + _seq
+/// separate Parquet file for RLS isolation. Uses Bloom filters on primary key columns
 /// columns for efficient query pruning.
 pub struct UserTableFlushJob {
     store: Arc<UserTableIndexedStore>,

--- a/backend/crates/kalamdb-handlers/crates/admin/src/compact/compact_all.rs
+++ b/backend/crates/kalamdb-handlers/crates/admin/src/compact/compact_all.rs
@@ -19,6 +19,8 @@ use kalamdb_jobs::{executors::compact::CompactParams, AppContextJobsExt};
 use kalamdb_sql::ddl::CompactAllTablesStatement;
 use kalamdb_system::JobType;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Handler for STORAGE COMPACT ALL
 pub struct CompactAllTablesHandler {
     app_context: Arc<AppContext>,
@@ -39,10 +41,7 @@ impl TypedStatementHandler<CompactAllTablesStatement> for CompactAllTablesHandle
     ) -> Result<ExecutionResult, KalamDbError> {
         // Offload sync RocksDB full table scan to blocking thread
         let app_ctx = self.app_context.clone();
-        let all_defs =
-            tokio::task::spawn_blocking(move || app_ctx.system_tables().tables().list_tables())
-                .await
-                .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let all_defs = run_blocking(move || app_ctx.system_tables().tables().list_tables()).await?;
         let ns = statement.namespace.clone();
         let target_tables: Vec<(TableName, TableType)> = all_defs
             .into_iter()

--- a/backend/crates/kalamdb-handlers/crates/admin/src/flush/flush_all.rs
+++ b/backend/crates/kalamdb-handlers/crates/admin/src/flush/flush_all.rs
@@ -16,6 +16,8 @@ use kalamdb_sql::ddl::FlushAllTablesStatement;
 use kalamdb_system::JobType;
 use tokio::task::JoinSet;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Handler for STORAGE FLUSH ALL
 pub struct FlushAllTablesHandler {
     app_context: Arc<AppContext>,
@@ -64,11 +66,10 @@ impl TypedStatementHandler<FlushAllTablesStatement> for FlushAllTablesHandler {
                 // Offload sync RocksDB read to blocking thread
                 let app_ctx_inner = app_context.clone();
                 let tid = table_id.clone();
-                let table_def = tokio::task::spawn_blocking(move || {
+                let table_def = run_blocking(move || {
                     app_ctx_inner.system_tables().tables().get_table_by_id(&tid)
                 })
-                .await
-                .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+                .await?;
 
                 let table_def = match table_def {
                     Some(def) => def,

--- a/backend/crates/kalamdb-handlers/crates/admin/src/helpers.rs
+++ b/backend/crates/kalamdb-handlers/crates/admin/src/helpers.rs
@@ -1,1 +1,2 @@
+pub use kalamdb_handlers_support::async_blocking;
 pub use kalamdb_handlers_support::audit;

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/helpers.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/helpers.rs
@@ -1,1 +1,1 @@
-pub use kalamdb_handlers_support::{audit, guards, storage, table_creation};
+pub use kalamdb_handlers_support::{async_blocking, audit, guards, storage, table_creation};

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/alter.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/alter.rs
@@ -13,7 +13,7 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::AlterNamespaceStatement;
 
-use crate::helpers::guards::require_admin;
+use crate::helpers::{async_blocking::run_blocking, guards::require_admin};
 
 /// Typed handler for ALTER NAMESPACE statements
 pub struct AlterNamespaceHandler {
@@ -41,7 +41,7 @@ impl TypedStatementHandler<AlterNamespaceStatement> for AlterNamespaceHandler {
         let ns_id = namespace_id.clone();
         let options = statement.options.clone();
         let name_owned = name.to_string();
-        tokio::task::spawn_blocking(move || {
+        run_blocking(move || {
             let namespaces_provider = app_ctx.system_tables().namespaces();
             let mut namespace = namespaces_provider.get_namespace(&ns_id)?.ok_or_else(|| {
                 KalamDbError::NotFound(format!("Namespace '{}' not found", name_owned))
@@ -65,8 +65,7 @@ impl TypedStatementHandler<AlterNamespaceStatement> for AlterNamespaceHandler {
             namespaces_provider.update_namespace(namespace)?;
             Ok::<_, KalamDbError>(())
         })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        .await?;
 
         // Log DDL operation
         use crate::helpers::audit;

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/create.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/create.rs
@@ -20,7 +20,7 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::CreateNamespaceStatement;
 
-use crate::helpers::guards::require_admin;
+use crate::helpers::{async_blocking::run_blocking, guards::require_admin};
 
 /// Typed handler for CREATE NAMESPACE statements
 pub struct CreateNamespaceHandler {
@@ -92,11 +92,9 @@ impl TypedStatementHandler<CreateNamespaceStatement> for CreateNamespaceHandler 
         let namespace_id = NamespaceId::new(name);
         let app_ctx = self.app_context.clone();
         let ns_id = namespace_id.clone();
-        let existing = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().namespaces().get_namespace(&ns_id)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let existing =
+            run_blocking(move || app_ctx.system_tables().namespaces().get_namespace(&ns_id))
+                .await?;
 
         if existing.is_some() {
             if statement.if_not_exists {

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/drop.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/drop.rs
@@ -18,6 +18,7 @@ use kalamdb_sql::ddl::DropNamespaceStatement;
 
 use crate::{
     helpers::{
+        async_blocking::run_blocking,
         audit,
         guards::{block_anonymous_write, require_admin},
     },
@@ -65,13 +66,12 @@ impl TypedStatementHandler<DropNamespaceStatement> for DropNamespaceHandler {
         // Check if namespace exists (offload sync RocksDB read)
         let app_ctx = self.app_context.clone();
         let ns_id = namespace_id.clone();
-        let (namespace_opt, tables_in_namespace) = tokio::task::spawn_blocking(move || {
+        let (namespace_opt, tables_in_namespace) = run_blocking(move || {
             let ns = app_ctx.system_tables().namespaces().get_namespace(&ns_id)?;
             let tables = app_ctx.system_tables().tables().list_tables_in_namespace(&ns_id)?;
             Ok::<_, KalamDbError>((ns, tables))
         })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        .await?;
 
         let namespace = match namespace_opt {
             Some(ns) => ns,
@@ -94,11 +94,9 @@ impl TypedStatementHandler<DropNamespaceStatement> for DropNamespaceHandler {
 
             let app_ctx = self.app_context.clone();
             let tid = table_id.clone();
-            let storage_details = tokio::task::spawn_blocking(move || {
-                capture_storage_cleanup_details(&app_ctx, &tid, table_type)
-            })
-            .await
-            .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+            let storage_details =
+                run_blocking(move || capture_storage_cleanup_details(&app_ctx, &tid, table_type))
+                    .await?;
 
             self.app_context
                 .applier()

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/show.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/show.rs
@@ -12,6 +12,8 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::ShowNamespacesStatement;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Typed handler for SHOW NAMESPACES statements
 pub struct ShowNamespacesHandler {
     app_context: Arc<AppContext>,
@@ -34,11 +36,9 @@ impl TypedStatementHandler<ShowNamespacesStatement> for ShowNamespacesHandler {
 
         // Query all namespaces via the table provider (offload sync RocksDB read)
         let app_ctx = self.app_context.clone();
-        let batches = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().namespaces().scan_all_namespaces()
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let batches =
+            run_blocking(move || app_ctx.system_tables().namespaces().scan_all_namespaces())
+                .await?;
 
         // Log query operation
         let duration = start_time.elapsed().as_secs_f64() * 1000.0;

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/use_namespace.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/namespace/use_namespace.rs
@@ -21,6 +21,8 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::UseNamespaceStatement;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Handler for USE NAMESPACE / USE / SET NAMESPACE statements
 ///
 /// Uses DataFusion's native `datafusion.catalog.default_schema` configuration
@@ -48,11 +50,8 @@ impl TypedStatementHandler<UseNamespaceStatement> for UseNamespaceHandler {
         // Verify namespace exists (offload sync RocksDB read)
         let app_ctx = self.app_context.clone();
         let ns = statement.namespace.clone();
-        let exists = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().namespaces().get_namespace(&ns)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let exists =
+            run_blocking(move || app_ctx.system_tables().namespaces().get_namespace(&ns)).await?;
 
         if exists.is_none() {
             return Err(KalamDbError::NotFound(format!(

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/storage/alter.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/storage/alter.rs
@@ -14,7 +14,7 @@ use kalamdb_core::{
 use kalamdb_filestore::StorageHealthService;
 use kalamdb_sql::ddl::AlterStorageStatement;
 
-use crate::helpers::guards::require_admin;
+use crate::helpers::{async_blocking::run_blocking, guards::require_admin};
 
 /// Typed handler for ALTER STORAGE statements
 pub struct AlterStorageHandler {
@@ -40,18 +40,16 @@ impl TypedStatementHandler<AlterStorageStatement> for AlterStorageHandler {
         let storage_id = statement.storage_id.clone();
         let app_ctx = self.app_context.clone();
         let sid = storage_id.clone();
-        let mut storage = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().storages().get_storage_by_id(&sid)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))?
-        .into_kalamdb_error("Failed to get storage")?
-        .ok_or_else(|| {
-            KalamDbError::InvalidOperation(format!(
-                "Storage '{}' not found",
-                statement.storage_id.as_str()
-            ))
-        })?;
+        let mut storage =
+            run_blocking(move || app_ctx.system_tables().storages().get_storage_by_id(&sid))
+                .await
+                .into_kalamdb_error("Failed to get storage")?
+                .ok_or_else(|| {
+                    KalamDbError::InvalidOperation(format!(
+                        "Storage '{}' not found",
+                        statement.storage_id.as_str()
+                    ))
+                })?;
 
         // Update fields if provided
         if let Some(name) = statement.storage_name {
@@ -130,12 +128,9 @@ impl TypedStatementHandler<AlterStorageStatement> for AlterStorageHandler {
 
         // Save updated storage (offload sync RocksDB write)
         let app_ctx = self.app_context.clone();
-        tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().storages().update_storage(storage)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))?
-        .into_kalamdb_error("Failed to update storage")?;
+        run_blocking(move || app_ctx.system_tables().storages().update_storage(storage))
+            .await
+            .into_kalamdb_error("Failed to update storage")?;
 
         // Invalidate storage cache to ensure fresh data on next access
         storage_registry.invalidate(&storage_id);

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/storage/check.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/storage/check.rs
@@ -19,7 +19,7 @@ use kalamdb_core::{
 use kalamdb_filestore::{HealthStatus, StorageHealthService};
 use kalamdb_sql::ddl::CheckStorageStatement;
 
-use crate::helpers::guards::require_admin;
+use crate::helpers::{async_blocking::run_blocking, guards::require_admin};
 
 /// Typed handler for STORAGE CHECK statements
 pub struct CheckStorageHandler {
@@ -59,15 +59,16 @@ impl TypedStatementHandler<CheckStorageStatement> for CheckStorageHandler {
         // Get the storage by ID (offload sync RocksDB read)
         let app_ctx = self.app_context.clone();
         let sid = statement.storage_id.clone();
-        let storage = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().storages().get_storage_by_id(&sid)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))?
-        .into_kalamdb_error("Failed to get storage")?
-        .ok_or_else(|| {
-            KalamDbError::NotFound(format!("Storage '{}' not found", statement.storage_id.as_str()))
-        })?;
+        let storage =
+            run_blocking(move || app_ctx.system_tables().storages().get_storage_by_id(&sid))
+                .await
+                .into_kalamdb_error("Failed to get storage")?
+                .ok_or_else(|| {
+                    KalamDbError::NotFound(format!(
+                        "Storage '{}' not found",
+                        statement.storage_id.as_str()
+                    ))
+                })?;
 
         // Run the health check
         let mut health_result = StorageHealthService::run_full_health_check(&storage)

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/storage/create.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/storage/create.rs
@@ -16,7 +16,9 @@ use kalamdb_filestore::StorageHealthService;
 use kalamdb_sql::ddl::CreateStorageStatement;
 use kalamdb_system::StorageType;
 
-use crate::helpers::{guards::require_admin, storage::ensure_filesystem_directory};
+use crate::helpers::{
+    async_blocking::run_blocking, guards::require_admin, storage::ensure_filesystem_directory,
+};
 
 /// Typed handler for CREATE STORAGE statements
 pub struct CreateStorageHandler {
@@ -43,12 +45,10 @@ impl TypedStatementHandler<CreateStorageStatement> for CreateStorageHandler {
         let storage_id = StorageId::from(statement.storage_id.as_str());
         let app_ctx = self.app_context.clone();
         let sid = storage_id.clone();
-        let existing = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().storages().get_storage_by_id(&sid)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))?
-        .into_kalamdb_error("Failed to check storage")?;
+        let existing =
+            run_blocking(move || app_ctx.system_tables().storages().get_storage_by_id(&sid))
+                .await
+                .into_kalamdb_error("Failed to check storage")?;
         if existing.is_some() {
             return Err(KalamDbError::InvalidOperation(format!(
                 "Storage '{}' already exists",

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/storage/drop.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/storage/drop.rs
@@ -12,7 +12,7 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::DropStorageStatement;
 
-use crate::helpers::guards::require_admin;
+use crate::helpers::{async_blocking::run_blocking, guards::require_admin};
 
 /// Typed handler for DROP STORAGE statements
 pub struct DropStorageHandler {
@@ -37,7 +37,7 @@ impl TypedStatementHandler<DropStorageStatement> for DropStorageHandler {
         // Check if storage exists and if any tables use it (offload sync RocksDB reads)
         let app_ctx = self.app_context.clone();
         let sid = storage_id.clone();
-        let (storage, tables_using_storage_count) = tokio::task::spawn_blocking(move || {
+        let (storage, tables_using_storage_count) = run_blocking(move || {
             let storages_provider = app_ctx.system_tables().storages();
             let tables_provider = app_ctx.system_tables().tables();
 
@@ -66,8 +66,7 @@ impl TypedStatementHandler<DropStorageStatement> for DropStorageHandler {
             };
             Ok::<_, KalamDbError>((storage, count))
         })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        .await?;
 
         if storage.is_none() {
             if statement.if_exists {

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/storage/show.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/storage/show.rs
@@ -12,6 +12,8 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::ShowStoragesStatement;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Typed handler for SHOW STORAGES statements
 pub struct ShowStoragesHandler {
     app_context: Arc<AppContext>,
@@ -32,11 +34,8 @@ impl TypedStatementHandler<ShowStoragesStatement> for ShowStoragesHandler {
     ) -> Result<ExecutionResult, KalamDbError> {
         // Query all storages (offload sync RocksDB read)
         let app_ctx = self.app_context.clone();
-        let batches = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().storages().scan_all_storages()
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let batches =
+            run_blocking(move || app_ctx.system_tables().storages().scan_all_storages()).await?;
 
         // Return as query result
         let row_count = batches.num_rows();

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/table/alter.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/table/alter.rs
@@ -1017,6 +1017,9 @@ fn apply_table_property_updates(
             if updates.access_level.is_some() {
                 return Err(unsupported_table_property("ACCESS_LEVEL", "STREAM"));
             }
+            if updates.compression.is_some() {
+                return Err(unsupported_table_property("COMPRESSION", "STREAM"));
+            }
 
             let mut changed = false;
             let mut changes = Vec::new();
@@ -1036,12 +1039,6 @@ fn apply_table_property_updates(
                 opts.max_stream_size_bytes = max_stream_size_bytes;
                 changes.push(format!("MAX_STREAM_SIZE_BYTES={}", max_stream_size_bytes));
             }
-            if let Some(compression) = &updates.compression {
-                changed |= &opts.compression != compression;
-                opts.compression = compression.clone();
-                changes.push(format!("COMPRESSION={}", compression));
-            }
-
             Ok((format_table_property_change(changes), changed))
         },
         TableOptions::System(_) => Err(KalamDbError::InvalidOperation(

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/table/create.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/table/create.rs
@@ -14,6 +14,8 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::CreateTableStatement;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Typed handler for CREATE TABLE statements (all table types: USER, SHARED, STREAM)
 pub struct CreateTableHandler {
     app_context: Arc<AppContext>,
@@ -35,14 +37,14 @@ impl CreateTableHandler {
         let app_ctx = self.app_context.clone();
         let table_id = TableId::new(statement.namespace_id.clone(), statement.table_name.clone());
 
-        tokio::task::spawn_blocking(move || {
+        run_blocking(move || {
             let schema_registry = app_ctx.schema_registry();
             let existing_def = schema_registry
                 .get_table_if_exists(&table_id)
                 .into_kalamdb_error("Failed to check table existence")?;
 
             let Some(existing_def) = existing_def else {
-                return Ok(None);
+                return Ok::<Option<String>, KalamDbError>(None);
             };
 
             if schema_registry.get_provider(&table_id).is_none() {
@@ -53,7 +55,6 @@ impl CreateTableHandler {
             Ok(Some(format!("Table {} already exists (IF NOT EXISTS)", table_id)))
         })
         .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))?
     }
 
     fn resolve_table_type(
@@ -111,11 +112,10 @@ impl TypedStatementHandler<CreateTableStatement> for CreateTableHandler {
         let stmt_clone = statement.clone();
         let user_id = context.user_id().clone();
         let user_role = context.user_role();
-        let table_def = tokio::task::spawn_blocking(move || {
+        let table_def = run_blocking(move || {
             table_creation::build_table_definition(app_ctx, &stmt_clone, &user_id, user_role)
         })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        .await?;
 
         // Delegate to unified applier - pass raw parameters
         let message = self

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/table/drop.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/table/drop.rs
@@ -23,6 +23,7 @@ use kalamdb_sql::ddl::DropTableStatement;
 use kalamdb_system::JobType;
 
 use crate::helpers::{
+    async_blocking::run_blocking,
     audit,
     guards::{block_anonymous_write, block_system_namespace_modification},
 };
@@ -181,11 +182,8 @@ impl TypedStatementHandler<DropTableStatement> for DropTableHandler {
         // Offload sync RocksDB read to blocking thread
         let app_ctx = self.app_context.clone();
         let tid = table_id.clone();
-        let table_metadata = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().tables().get_table_by_id(&tid)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let table_metadata =
+            run_blocking(move || app_ctx.system_tables().tables().get_table_by_id(&tid)).await?;
         let exists = table_metadata.is_some() || registry_def.is_some();
 
         if !exists {
@@ -229,11 +227,8 @@ impl TypedStatementHandler<DropTableStatement> for DropTableHandler {
         let app_ctx = self.app_context.clone();
         let tid = table_id.clone();
         let at = actual_type;
-        let storage_details = tokio::task::spawn_blocking(move || {
-            capture_storage_cleanup_details(&app_ctx, &tid, at)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let storage_details =
+            run_blocking(move || capture_storage_cleanup_details(&app_ctx, &tid, at)).await?;
 
         // Cancel any active flush jobs for this table before dropping
         let job_manager = self.app_context.job_manager();

--- a/backend/crates/kalamdb-handlers/crates/ddl/src/table/show.rs
+++ b/backend/crates/kalamdb-handlers/crates/ddl/src/table/show.rs
@@ -21,6 +21,8 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::ShowTablesStatement;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Typed handler for SHOW TABLES statements
 pub struct ShowTablesHandler {
     app_context: Arc<AppContext>,
@@ -44,7 +46,7 @@ impl TypedStatementHandler<ShowTablesStatement> for ShowTablesHandler {
         // Offload sync RocksDB reads to blocking pool
         let app_ctx = self.app_context.clone();
         let ns_filter = statement.namespace_id;
-        let result = tokio::task::spawn_blocking(move || {
+        let result = run_blocking(move || {
             let tables_provider = app_ctx.system_tables().tables();
             if let Some(ns) = ns_filter {
                 let defs = tables_provider.list_tables()?;
@@ -67,8 +69,7 @@ impl TypedStatementHandler<ShowTablesStatement> for ShowTablesHandler {
                 })
             }
         })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))?;
+        .await?;
 
         // Log query operation
         let duration = start_time.elapsed().as_secs_f64() * 1000.0;
@@ -76,7 +77,7 @@ impl TypedStatementHandler<ShowTablesStatement> for ShowTablesHandler {
         let audit_entry = audit::log_query_operation(context, "SHOW", "TABLES", duration, None);
         audit::persist_audit_entry(&self.app_context, &audit_entry).await?;
 
-        result
+        Ok(result)
     }
 
     async fn check_authorization(

--- a/backend/crates/kalamdb-handlers/crates/stream/Cargo.toml
+++ b/backend/crates/kalamdb-handlers/crates/stream/Cargo.toml
@@ -12,12 +12,13 @@ description = "Stream and topic SQL handlers for KalamDB"
 kalamdb-commons = { path = "../../../kalamdb-commons", default-features = false }
 kalamdb-core = { path = "../../../kalamdb-core" }
 kalamdb-handlers-support = { path = "../support" }
+kalamdb-observability = { path = "../../../kalamdb-observability" }
 kalamdb-sql = { package = "kalamdb-dialect", path = "../../../kalamdb-dialect" }
 kalamdb-system = { path = "../../../kalamdb-system" }
 kalamdb-tables = { path = "../../../kalamdb-tables" }
 
+arrow = { workspace = true }
 chrono = { workspace = true }
-datafusion = { workspace = true }
 log = { workspace = true }
 
 [lib]

--- a/backend/crates/kalamdb-handlers/crates/stream/src/result_rows.rs
+++ b/backend/crates/kalamdb-handlers/crates/stream/src/result_rows.rs
@@ -1,11 +1,39 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use datafusion::arrow::{
+use arrow::{
     array::{ArrayRef, Int32Array, Int64Array, StringBuilder},
-    datatypes::{DataType, Field, Schema},
+    datatypes::{DataType, Field, Schema, SchemaRef},
     record_batch::RecordBatch,
 };
 use kalamdb_core::{error::KalamDbError, sql::context::ExecutionResult};
+
+fn ack_schema() -> SchemaRef {
+    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
+    SCHEMA
+        .get_or_init(|| {
+            Arc::new(Schema::new(vec![
+                Field::new("topic", DataType::Utf8, false),
+                Field::new("group_id", DataType::Utf8, false),
+                Field::new("partition", DataType::Int32, false),
+                Field::new("committed_offset", DataType::Int64, false),
+            ]))
+        })
+        .clone()
+}
+
+fn reset_consumer_group_schema() -> SchemaRef {
+    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
+    SCHEMA
+        .get_or_init(|| {
+            Arc::new(Schema::new(vec![
+                Field::new("topic", DataType::Utf8, false),
+                Field::new("group_id", DataType::Utf8, false),
+                Field::new("partition", DataType::Int32, false),
+                Field::new("next_offset", DataType::Int64, false),
+            ]))
+        })
+        .clone()
+}
 
 pub fn ack_result(
     topic_name: &str,
@@ -13,12 +41,7 @@ pub fn ack_result(
     partition_id: u32,
     upto_offset: u64,
 ) -> Result<ExecutionResult, KalamDbError> {
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("topic", DataType::Utf8, false),
-        Field::new("group_id", DataType::Utf8, false),
-        Field::new("partition", DataType::Int32, false),
-        Field::new("committed_offset", DataType::Int64, false),
-    ]));
+    let schema = ack_schema();
 
     let mut topic_builder = StringBuilder::new();
     let mut group_builder = StringBuilder::new();
@@ -51,12 +74,7 @@ pub fn reset_consumer_group_result(
     partition_id: u32,
     next_offset: u64,
 ) -> Result<ExecutionResult, KalamDbError> {
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("topic", DataType::Utf8, false),
-        Field::new("group_id", DataType::Utf8, false),
-        Field::new("partition", DataType::Int32, false),
-        Field::new("next_offset", DataType::Int64, false),
-    ]));
+    let schema = reset_consumer_group_schema();
 
     let mut topic_builder = StringBuilder::new();
     let mut group_builder = StringBuilder::new();

--- a/backend/crates/kalamdb-handlers/crates/stream/src/topics/consume.rs
+++ b/backend/crates/kalamdb-handlers/crates/stream/src/topics/consume.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use datafusion::arrow::{
+use arrow::{
     array::{ArrayRef, BinaryBuilder, Int32Array, Int64Array, StringBuilder},
     record_batch::RecordBatch,
 };
@@ -13,6 +13,7 @@ use kalamdb_core::{
         executor::handlers::TypedStatementHandler,
     },
 };
+use kalamdb_observability::track_pubsub_consumer;
 use kalamdb_sql::ddl::{ConsumePosition, ConsumeStatement};
 use kalamdb_tables::topics::topic_message_schema::topic_message_schema;
 
@@ -40,6 +41,7 @@ impl TypedStatementHandler<ConsumeStatement> for ConsumeHandler {
         })?;
 
         let topic_publisher = self.app_context.topic_publisher();
+        let _consumer_guard = track_pubsub_consumer();
         let limit = statement.limit.unwrap_or(100) as usize;
         let partition_id = 0u32;
         let group_id =

--- a/backend/crates/kalamdb-handlers/crates/support/Cargo.toml
+++ b/backend/crates/kalamdb-handlers/crates/support/Cargo.toml
@@ -18,6 +18,7 @@ kalamdb-system = { path = "../../../kalamdb-system" }
 chrono = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/backend/crates/kalamdb-handlers/crates/support/src/async_blocking.rs
+++ b/backend/crates/kalamdb-handlers/crates/support/src/async_blocking.rs
@@ -1,0 +1,15 @@
+use kalamdb_core::error::KalamDbError;
+
+pub async fn run_blocking<T, E, F>(operation: F) -> Result<T, KalamDbError>
+where
+    T: Send + 'static,
+    E: Into<KalamDbError> + Send + 'static,
+    F: FnOnce() -> Result<T, E> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|join_error| {
+            KalamDbError::ExecutionError(format!("Task join error: {}", join_error))
+        })?
+        .map_err(Into::into)
+}

--- a/backend/crates/kalamdb-handlers/crates/support/src/lib.rs
+++ b/backend/crates/kalamdb-handlers/crates/support/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod async_blocking;
 pub mod audit;
 pub mod guards;
 pub mod storage;

--- a/backend/crates/kalamdb-handlers/crates/support/src/table_creation.rs
+++ b/backend/crates/kalamdb-handlers/crates/support/src/table_creation.rs
@@ -404,9 +404,6 @@ pub fn build_table_definition(
             if let Some(ttl) = stmt.ttl_seconds {
                 opts.ttl_seconds = ttl;
             }
-            if let Some(compression) = &stmt.compression {
-                opts.compression = compression.clone();
-            }
             if let Some(eviction_strategy) = &stmt.eviction_strategy {
                 opts.eviction_strategy = eviction_strategy.clone();
             }

--- a/backend/crates/kalamdb-handlers/crates/user/src/helpers.rs
+++ b/backend/crates/kalamdb-handlers/crates/user/src/helpers.rs
@@ -1,1 +1,2 @@
+pub use kalamdb_handlers_support::async_blocking;
 pub use kalamdb_handlers_support::audit;

--- a/backend/crates/kalamdb-handlers/crates/user/src/user/alter.rs
+++ b/backend/crates/kalamdb-handlers/crates/user/src/user/alter.rs
@@ -17,6 +17,8 @@ use kalamdb_core::{
 use kalamdb_sql::ddl::{AlterUserStatement, UserModification};
 use kalamdb_system::Role;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Handler for ALTER USER
 pub struct AlterUserHandler {
     app_context: Arc<AppContext>,
@@ -42,14 +44,12 @@ impl TypedStatementHandler<AlterUserStatement> for AlterUserHandler {
         let app_ctx = self.app_context.clone();
         let user_id = UserId::try_new(statement.username.clone())
             .map_err(|e| KalamDbError::InvalidOperation(e.to_string()))?;
-        let existing = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().users().get_user_by_id(&user_id)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??
-        .ok_or_else(|| {
-            KalamDbError::NotFound(format!("User '{}' not found", statement.username))
-        })?;
+        let existing =
+            run_blocking(move || app_ctx.system_tables().users().get_user_by_id(&user_id))
+                .await?
+                .ok_or_else(|| {
+                    KalamDbError::NotFound(format!("User '{}' not found", statement.username))
+                })?;
 
         let mut updated = existing.clone();
 
@@ -109,13 +109,10 @@ impl TypedStatementHandler<AlterUserStatement> for AlterUserHandler {
                 if let Some(storage_id) = new_storage_id {
                     let app_ctx = self.app_context.clone();
                     let storage_lookup_id = storage_id.clone();
-                    let storage = tokio::task::spawn_blocking(move || {
+                    let storage = run_blocking(move || {
                         app_ctx.system_tables().storages().get_storage_by_id(&storage_lookup_id)
                     })
-                    .await
-                    .map_err(|e| {
-                        KalamDbError::ExecutionError(format!("Task join error: {}", e))
-                    })??;
+                    .await?;
 
                     if storage.is_none() {
                         return Err(KalamDbError::InvalidOperation(format!(

--- a/backend/crates/kalamdb-handlers/crates/user/src/user/create.rs
+++ b/backend/crates/kalamdb-handlers/crates/user/src/user/create.rs
@@ -18,6 +18,8 @@ use kalamdb_core::{
 use kalamdb_sql::ddl::CreateUserStatement;
 use kalamdb_system::{AuthData, User};
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Handler for CREATE USER
 pub struct CreateUserHandler {
     app_context: Arc<AppContext>,
@@ -45,11 +47,8 @@ impl TypedStatementHandler<CreateUserStatement> for CreateUserHandler {
         let user_id = UserId::try_new(statement.username.clone())
             .map_err(|e| KalamDbError::InvalidOperation(e.to_string()))?;
         let check_id = user_id.clone();
-        let existing = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().users().get_user_by_id(&check_id)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let existing =
+            run_blocking(move || app_ctx.system_tables().users().get_user_by_id(&check_id)).await?;
         if existing.is_some() {
             return Err(KalamDbError::AlreadyExists(format!(
                 "User '{}' already exists",
@@ -60,11 +59,10 @@ impl TypedStatementHandler<CreateUserStatement> for CreateUserHandler {
         let storage_id = if let Some(storage_id) = statement.storage_id.clone() {
             let app_ctx = self.app_context.clone();
             let storage_lookup_id = storage_id.clone();
-            let storage = tokio::task::spawn_blocking(move || {
+            let storage = run_blocking(move || {
                 app_ctx.system_tables().storages().get_storage_by_id(&storage_lookup_id)
             })
-            .await
-            .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+            .await?;
 
             if storage.is_none() {
                 return Err(KalamDbError::InvalidOperation(format!(

--- a/backend/crates/kalamdb-handlers/crates/user/src/user/drop.rs
+++ b/backend/crates/kalamdb-handlers/crates/user/src/user/drop.rs
@@ -13,6 +13,8 @@ use kalamdb_core::{
 };
 use kalamdb_sql::ddl::DropUserStatement;
 
+use crate::helpers::async_blocking::run_blocking;
+
 /// Handler for DROP USER
 pub struct DropUserHandler {
     app_context: Arc<AppContext>,
@@ -34,11 +36,8 @@ impl TypedStatementHandler<DropUserStatement> for DropUserHandler {
         let app_ctx = self.app_context.clone();
         let user_id = UserId::try_new(statement.username.clone())
             .map_err(|e| KalamDbError::InvalidOperation(e.to_string()))?;
-        let existing = tokio::task::spawn_blocking(move || {
-            app_ctx.system_tables().users().get_user_by_id(&user_id)
-        })
-        .await
-        .map_err(|e| KalamDbError::ExecutionError(format!("Task join error: {}", e)))??;
+        let existing =
+            run_blocking(move || app_ctx.system_tables().users().get_user_by_id(&user_id)).await?;
         if existing.is_none() {
             if statement.if_exists {
                 return Ok(ExecutionResult::Success {

--- a/backend/crates/kalamdb-jobs/src/executors/flush.rs
+++ b/backend/crates/kalamdb-jobs/src/executors/flush.rs
@@ -213,6 +213,7 @@ impl FlushExecutor {
             cached.schema_version,
             cached.bloom_filter_columns().to_vec(),
             cached.indexed_columns().to_vec(),
+            cached.table.table_options.parquet_compression(),
         );
         let scan_batch_size = app_ctx.config().flush.flush_batch_size;
         let scope_hook = Arc::new(CoreFlushScopeHook::new(app_ctx));

--- a/backend/crates/kalamdb-live/Cargo.toml
+++ b/backend/crates/kalamdb-live/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 # Internal crates
 kalamdb-commons = { path = "../kalamdb-commons", features = ["full"] }
+kalamdb-observability = { path = "../kalamdb-observability" }
 kalamdb-row-filter = { workspace = true }
 kalamdb-publisher = { path = "../kalamdb-publisher" }
 kalamdb-system = { path = "../kalamdb-system" }

--- a/backend/crates/kalamdb-live/src/manager/queries_manager.rs
+++ b/backend/crates/kalamdb-live/src/manager/queries_manager.rs
@@ -517,7 +517,7 @@ mod tests {
     use kalamdb_commons::{
         models::{NamespaceId, TableId, TableName, UserId},
         schemas::{
-            table_options::{SharedTableOptions, SystemTableOptions},
+            table_options::{SharedTableOptions, SystemTableOptions, TableCompression},
             TableDefinition, TableOptions,
         },
         Role, TableAccess, TableType,
@@ -546,7 +546,7 @@ mod tests {
                 storage_id: kalamdb_commons::StorageId::from("default"),
                 access_level: Some(access),
                 flush_policy: None,
-                compression: "none".to_string(),
+                compression: TableCompression::Snappy,
             }),
             table_comment: None,
             created_at: chrono::Utc::now(),

--- a/backend/crates/kalamdb-live/src/notification.rs
+++ b/backend/crates/kalamdb-live/src/notification.rs
@@ -22,6 +22,7 @@ use kalamdb_commons::{
     models::{rows::Row, LiveQueryId, TableId, UserId},
     websocket::{RowData, SharedChangePayload, WireNotification},
 };
+use kalamdb_observability::record_subscription_changes_delivered;
 use kalamdb_system::NotificationService as NotificationServiceTrait;
 use tokio::sync::mpsc;
 
@@ -395,15 +396,16 @@ impl NotificationService {
             return;
         }
 
-        if let Err(e) =
-            Self::dispatch_to_subscribers(&task.table_id, task.notification, handles).await
-        {
-            log::warn!(
-                "[worker-{}] Failed to notify subscribers for table {}: {}",
-                worker_idx,
-                task.table_id,
-                e
-            );
+        match Self::dispatch_to_subscribers(&task.table_id, task.notification, handles).await {
+            Ok(delivered) => record_subscription_changes_delivered(delivered as u64),
+            Err(e) => {
+                log::warn!(
+                    "[worker-{}] Failed to notify subscribers for table {}: {}",
+                    worker_idx,
+                    task.table_id,
+                    e
+                );
+            },
         }
     }
 

--- a/backend/crates/kalamdb-observability/Cargo.toml
+++ b/backend/crates/kalamdb-observability/Cargo.toml
@@ -15,9 +15,13 @@ num_cpus = { workspace = true }
 
 # Logging
 log = { workspace = true }
+tracing = { workspace = true, optional = true }
 libmimalloc-sys = { workspace = true, optional = true }
 
 [features]
+default = ["metrics"]
+metrics = []
+traceability = ["dep:tracing"]
 mimalloc = ["dep:libmimalloc-sys"]
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/backend/crates/kalamdb-observability/src/health_monitor.rs
+++ b/backend/crates/kalamdb-observability/src/health_monitor.rs
@@ -80,10 +80,16 @@ pub struct HealthMonitor;
 impl HealthMonitor {
     /// Collect open file metrics without refreshing process CPU/memory stats.
     pub fn collect_open_file_metrics() -> (usize, Option<OpenFileBreakdown>) {
-        #[cfg(unix)]
-        let open_file_breakdown = Self::collect_open_file_breakdown();
-        #[cfg(not(unix))]
-        let open_file_breakdown = None;
+        let open_file_breakdown: Option<OpenFileBreakdown> = {
+            #[cfg(unix)]
+            {
+                Self::collect_open_file_breakdown()
+            }
+            #[cfg(not(unix))]
+            {
+                None
+            }
+        };
 
         let open_files = open_file_breakdown.map(|breakdown| breakdown.total).unwrap_or(0);
         (open_files, open_file_breakdown)

--- a/backend/crates/kalamdb-observability/src/lib.rs
+++ b/backend/crates/kalamdb-observability/src/lib.rs
@@ -14,10 +14,12 @@ pub mod activity;
 pub mod allocator_metrics;
 pub mod cpu;
 pub mod health_monitor;
+pub mod pubsub_metrics;
 pub mod query_metrics;
 pub mod runtime_metrics;
 pub mod storage_metrics;
 pub mod system_stats;
+pub mod trace;
 
 pub use activity::{idle_duration, initialize_activity_now, last_activity_ms, record_activity_now};
 pub use allocator_metrics::{
@@ -27,6 +29,11 @@ pub use cpu::{get_cpu_count, get_physical_cpu_count};
 pub use health_monitor::{
     decrement_websocket_sessions, get_websocket_session_count, get_websocket_session_peak_count,
     increment_websocket_sessions, HealthCounts, HealthMetrics, HealthMonitor,
+};
+pub use pubsub_metrics::{
+    pubsub_metrics_snapshot, record_pubsub_messages_consumed, record_pubsub_messages_published,
+    record_subscription_changes_delivered, track_pubsub_consumer, PubSubConsumerGuard,
+    PubSubMetricsSnapshot,
 };
 pub use query_metrics::{
     observe_query, query_metrics_snapshot, should_observe_query_namespace, QueryMetricKind,
@@ -46,3 +53,4 @@ pub use system_stats::{
     collect_system_stats, CacheMetrics, ClusterMetrics, EntityCounts, LiveQueryMetrics,
     ServerConfigMetrics, SystemStatsSource,
 };
+pub use trace::NoopSpanGuard;

--- a/backend/crates/kalamdb-observability/src/pubsub_metrics.rs
+++ b/backend/crates/kalamdb-observability/src/pubsub_metrics.rs
@@ -1,0 +1,382 @@
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    OnceLock,
+};
+
+const RATE_WINDOW_SECS: u64 = 60;
+const RATE_BUCKET_COUNT: usize = RATE_WINDOW_SECS as usize;
+
+static PUBSUB_MESSAGES_PUBLISHED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_BYTES_PUBLISHED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_MESSAGES_CONSUMED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_BYTES_CONSUMED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_ACTIVE_CONSUMERS: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_ACTIVE_CONSUMERS_PEAK: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_MESSAGES_PUBLISHED_PEAK_PER_SECOND: AtomicU64 = AtomicU64::new(0);
+static PUBSUB_MESSAGES_CONSUMED_PEAK_PER_SECOND: AtomicU64 = AtomicU64::new(0);
+static SUBSCRIPTION_CHANGES_DELIVERED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static FIRST_PUBSUB_EPOCH_SECOND: AtomicU64 = AtomicU64::new(0);
+
+struct RateBuckets {
+    epochs: [AtomicU64; RATE_BUCKET_COUNT],
+    amounts: [AtomicU64; RATE_BUCKET_COUNT],
+}
+
+impl RateBuckets {
+    fn new() -> Self {
+        Self {
+            epochs: std::array::from_fn(|_| AtomicU64::new(0)),
+            amounts: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+}
+
+static PUBSUB_PUBLISH_MESSAGE_RATE_BUCKETS: OnceLock<RateBuckets> = OnceLock::new();
+static PUBSUB_PUBLISH_BYTE_RATE_BUCKETS: OnceLock<RateBuckets> = OnceLock::new();
+static PUBSUB_CONSUME_MESSAGE_RATE_BUCKETS: OnceLock<RateBuckets> = OnceLock::new();
+static PUBSUB_CONSUME_BYTE_RATE_BUCKETS: OnceLock<RateBuckets> = OnceLock::new();
+static SUBSCRIPTION_DELIVERY_RATE_BUCKETS: OnceLock<RateBuckets> = OnceLock::new();
+
+fn publish_message_rate_buckets() -> &'static RateBuckets {
+    PUBSUB_PUBLISH_MESSAGE_RATE_BUCKETS.get_or_init(RateBuckets::new)
+}
+
+fn publish_byte_rate_buckets() -> &'static RateBuckets {
+    PUBSUB_PUBLISH_BYTE_RATE_BUCKETS.get_or_init(RateBuckets::new)
+}
+
+fn consume_message_rate_buckets() -> &'static RateBuckets {
+    PUBSUB_CONSUME_MESSAGE_RATE_BUCKETS.get_or_init(RateBuckets::new)
+}
+
+fn consume_byte_rate_buckets() -> &'static RateBuckets {
+    PUBSUB_CONSUME_BYTE_RATE_BUCKETS.get_or_init(RateBuckets::new)
+}
+
+fn subscription_delivery_rate_buckets() -> &'static RateBuckets {
+    SUBSCRIPTION_DELIVERY_RATE_BUCKETS.get_or_init(RateBuckets::new)
+}
+
+fn epoch_second() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn mark_first_pubsub_activity(now_second: u64) {
+    let _ = FIRST_PUBSUB_EPOCH_SECOND.compare_exchange(
+        0,
+        now_second,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    );
+}
+
+fn observe_rate_amount(buckets: &RateBuckets, now_second: u64, amount: u64) -> u64 {
+    if amount == 0 {
+        return 0;
+    }
+
+    let index = (now_second % RATE_WINDOW_SECS) as usize;
+    let bucket_epoch = &buckets.epochs[index];
+    let bucket_amount = &buckets.amounts[index];
+    let observed_epoch = bucket_epoch.load(Ordering::Acquire);
+    if observed_epoch != now_second
+        && bucket_epoch
+            .compare_exchange(observed_epoch, now_second, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    {
+        bucket_amount.store(0, Ordering::Release);
+    }
+
+    bucket_amount.fetch_add(amount, Ordering::Relaxed).saturating_add(amount)
+}
+
+fn snapshot_rate(buckets: &RateBuckets, now_second: u64, elapsed_window: u64) -> f64 {
+    let mut recent_amount = 0u64;
+    for index in 0..RATE_BUCKET_COUNT {
+        let bucket_epoch = buckets.epochs[index].load(Ordering::Acquire);
+        if bucket_epoch <= now_second && now_second.saturating_sub(bucket_epoch) < RATE_WINDOW_SECS
+        {
+            recent_amount =
+                recent_amount.saturating_add(buckets.amounts[index].load(Ordering::Relaxed));
+        }
+    }
+
+    recent_amount as f64 / elapsed_window as f64
+}
+
+fn pubsub_elapsed_window(now_second: u64) -> u64 {
+    let first_second = FIRST_PUBSUB_EPOCH_SECOND.load(Ordering::Acquire);
+    if first_second == 0 {
+        1
+    } else {
+        now_second
+            .saturating_sub(first_second)
+            .saturating_add(1)
+            .min(RATE_WINDOW_SECS)
+            .max(1)
+    }
+}
+
+fn update_peak(peak: &AtomicU64, candidate: u64) {
+    let mut current = peak.load(Ordering::Relaxed);
+    while candidate > current {
+        match peak.compare_exchange(current, candidate, Ordering::AcqRel, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PubSubConsumerGuard;
+
+impl Drop for PubSubConsumerGuard {
+    fn drop(&mut self) {
+        PUBSUB_ACTIVE_CONSUMERS.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+pub fn track_pubsub_consumer() -> PubSubConsumerGuard {
+    let active = PUBSUB_ACTIVE_CONSUMERS.fetch_add(1, Ordering::Relaxed).saturating_add(1);
+    update_peak(&PUBSUB_ACTIVE_CONSUMERS_PEAK, active);
+    PubSubConsumerGuard
+}
+
+pub fn record_pubsub_messages_published(message_count: u64, byte_count: u64) {
+    if message_count == 0 && byte_count == 0 {
+        return;
+    }
+
+    let now_second = epoch_second();
+    mark_first_pubsub_activity(now_second);
+
+    if message_count > 0 {
+        PUBSUB_MESSAGES_PUBLISHED_TOTAL.fetch_add(message_count, Ordering::Relaxed);
+        let bucket_total =
+            observe_rate_amount(publish_message_rate_buckets(), now_second, message_count);
+        update_peak(&PUBSUB_MESSAGES_PUBLISHED_PEAK_PER_SECOND, bucket_total);
+    }
+    if byte_count > 0 {
+        PUBSUB_BYTES_PUBLISHED_TOTAL.fetch_add(byte_count, Ordering::Relaxed);
+        observe_rate_amount(publish_byte_rate_buckets(), now_second, byte_count);
+    }
+}
+
+pub fn record_pubsub_messages_consumed(message_count: u64, byte_count: u64) {
+    if message_count == 0 && byte_count == 0 {
+        return;
+    }
+
+    let now_second = epoch_second();
+    mark_first_pubsub_activity(now_second);
+
+    if message_count > 0 {
+        PUBSUB_MESSAGES_CONSUMED_TOTAL.fetch_add(message_count, Ordering::Relaxed);
+        let bucket_total =
+            observe_rate_amount(consume_message_rate_buckets(), now_second, message_count);
+        update_peak(&PUBSUB_MESSAGES_CONSUMED_PEAK_PER_SECOND, bucket_total);
+    }
+    if byte_count > 0 {
+        PUBSUB_BYTES_CONSUMED_TOTAL.fetch_add(byte_count, Ordering::Relaxed);
+        observe_rate_amount(consume_byte_rate_buckets(), now_second, byte_count);
+    }
+}
+
+pub fn record_subscription_changes_delivered(change_count: u64) {
+    if change_count == 0 {
+        return;
+    }
+
+    let now_second = epoch_second();
+    mark_first_pubsub_activity(now_second);
+    SUBSCRIPTION_CHANGES_DELIVERED_TOTAL.fetch_add(change_count, Ordering::Relaxed);
+    observe_rate_amount(subscription_delivery_rate_buckets(), now_second, change_count);
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PubSubMetricsSnapshot {
+    pub pubsub_messages_published_total: u64,
+    pub pubsub_messages_published_per_second: f64,
+    pub pubsub_messages_published_peak_per_second: u64,
+    pub pubsub_bytes_published_total: u64,
+    pub pubsub_kb_published_per_second: f64,
+    pub pubsub_messages_consumed_total: u64,
+    pub pubsub_messages_consumed_per_second: f64,
+    pub pubsub_messages_consumed_peak_per_second: u64,
+    pub pubsub_bytes_consumed_total: u64,
+    pub pubsub_kb_consumed_per_second: f64,
+    pub pubsub_active_consumers: u64,
+    pub pubsub_active_consumers_peak: u64,
+    pub subscription_changes_delivered_total: u64,
+    pub subscription_changes_delivered_per_second: f64,
+}
+
+impl PubSubMetricsSnapshot {
+    pub fn as_pairs(&self) -> Vec<(String, String)> {
+        vec![
+            (
+                "pubsub_messages_published_total".to_string(),
+                self.pubsub_messages_published_total.to_string(),
+            ),
+            (
+                "pubsub_messages_published_per_second".to_string(),
+                format!("{:.2}", self.pubsub_messages_published_per_second),
+            ),
+            (
+                "pubsub_messages_published_peak_per_second".to_string(),
+                self.pubsub_messages_published_peak_per_second.to_string(),
+            ),
+            (
+                "pubsub_bytes_published_total".to_string(),
+                self.pubsub_bytes_published_total.to_string(),
+            ),
+            (
+                "pubsub_kb_published_per_second".to_string(),
+                format!("{:.2}", self.pubsub_kb_published_per_second),
+            ),
+            (
+                "pubsub_messages_consumed_total".to_string(),
+                self.pubsub_messages_consumed_total.to_string(),
+            ),
+            (
+                "pubsub_messages_consumed_per_second".to_string(),
+                format!("{:.2}", self.pubsub_messages_consumed_per_second),
+            ),
+            (
+                "pubsub_messages_consumed_peak_per_second".to_string(),
+                self.pubsub_messages_consumed_peak_per_second.to_string(),
+            ),
+            (
+                "pubsub_bytes_consumed_total".to_string(),
+                self.pubsub_bytes_consumed_total.to_string(),
+            ),
+            (
+                "pubsub_kb_consumed_per_second".to_string(),
+                format!("{:.2}", self.pubsub_kb_consumed_per_second),
+            ),
+            ("pubsub_active_consumers".to_string(), self.pubsub_active_consumers.to_string()),
+            (
+                "pubsub_active_consumers_peak".to_string(),
+                self.pubsub_active_consumers_peak.to_string(),
+            ),
+            (
+                "subscription_changes_delivered_total".to_string(),
+                self.subscription_changes_delivered_total.to_string(),
+            ),
+            (
+                "subscription_changes_delivered_per_second".to_string(),
+                format!("{:.2}", self.subscription_changes_delivered_per_second),
+            ),
+        ]
+    }
+}
+
+pub fn pubsub_metrics_snapshot() -> PubSubMetricsSnapshot {
+    let now_second = epoch_second();
+    let elapsed_window = pubsub_elapsed_window(now_second);
+
+    PubSubMetricsSnapshot {
+        pubsub_messages_published_total: PUBSUB_MESSAGES_PUBLISHED_TOTAL.load(Ordering::Relaxed),
+        pubsub_messages_published_per_second: snapshot_rate(
+            publish_message_rate_buckets(),
+            now_second,
+            elapsed_window,
+        ),
+        pubsub_messages_published_peak_per_second: PUBSUB_MESSAGES_PUBLISHED_PEAK_PER_SECOND
+            .load(Ordering::Relaxed),
+        pubsub_bytes_published_total: PUBSUB_BYTES_PUBLISHED_TOTAL.load(Ordering::Relaxed),
+        pubsub_kb_published_per_second: snapshot_rate(
+            publish_byte_rate_buckets(),
+            now_second,
+            elapsed_window,
+        ) / 1024.0,
+        pubsub_messages_consumed_total: PUBSUB_MESSAGES_CONSUMED_TOTAL.load(Ordering::Relaxed),
+        pubsub_messages_consumed_per_second: snapshot_rate(
+            consume_message_rate_buckets(),
+            now_second,
+            elapsed_window,
+        ),
+        pubsub_messages_consumed_peak_per_second: PUBSUB_MESSAGES_CONSUMED_PEAK_PER_SECOND
+            .load(Ordering::Relaxed),
+        pubsub_bytes_consumed_total: PUBSUB_BYTES_CONSUMED_TOTAL.load(Ordering::Relaxed),
+        pubsub_kb_consumed_per_second: snapshot_rate(
+            consume_byte_rate_buckets(),
+            now_second,
+            elapsed_window,
+        ) / 1024.0,
+        pubsub_active_consumers: PUBSUB_ACTIVE_CONSUMERS.load(Ordering::Relaxed),
+        pubsub_active_consumers_peak: PUBSUB_ACTIVE_CONSUMERS_PEAK.load(Ordering::Relaxed),
+        subscription_changes_delivered_total: SUBSCRIPTION_CHANGES_DELIVERED_TOTAL
+            .load(Ordering::Relaxed),
+        subscription_changes_delivered_per_second: snapshot_rate(
+            subscription_delivery_rate_buckets(),
+            now_second,
+            elapsed_window,
+        ),
+    }
+}
+
+#[cfg(test)]
+fn reset_pubsub_metrics_for_tests() {
+    PUBSUB_MESSAGES_PUBLISHED_TOTAL.store(0, Ordering::Relaxed);
+    PUBSUB_BYTES_PUBLISHED_TOTAL.store(0, Ordering::Relaxed);
+    PUBSUB_MESSAGES_CONSUMED_TOTAL.store(0, Ordering::Relaxed);
+    PUBSUB_BYTES_CONSUMED_TOTAL.store(0, Ordering::Relaxed);
+    PUBSUB_ACTIVE_CONSUMERS.store(0, Ordering::Relaxed);
+    PUBSUB_ACTIVE_CONSUMERS_PEAK.store(0, Ordering::Relaxed);
+    PUBSUB_MESSAGES_PUBLISHED_PEAK_PER_SECOND.store(0, Ordering::Relaxed);
+    PUBSUB_MESSAGES_CONSUMED_PEAK_PER_SECOND.store(0, Ordering::Relaxed);
+    SUBSCRIPTION_CHANGES_DELIVERED_TOTAL.store(0, Ordering::Relaxed);
+    FIRST_PUBSUB_EPOCH_SECOND.store(0, Ordering::Relaxed);
+
+    for buckets in [
+        publish_message_rate_buckets(),
+        publish_byte_rate_buckets(),
+        consume_message_rate_buckets(),
+        consume_byte_rate_buckets(),
+        subscription_delivery_rate_buckets(),
+    ] {
+        for index in 0..RATE_BUCKET_COUNT {
+            buckets.epochs[index].store(0, Ordering::Relaxed);
+            buckets.amounts[index].store(0, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pubsub_metrics_snapshot_tracks_counts_rates_and_active_consumers() {
+        reset_pubsub_metrics_for_tests();
+
+        {
+            let _consumer_guard = track_pubsub_consumer();
+            record_pubsub_messages_published(3, 3_072);
+            record_pubsub_messages_consumed(2, 1_024);
+            record_subscription_changes_delivered(5);
+
+            let snapshot = pubsub_metrics_snapshot();
+            assert_eq!(snapshot.pubsub_active_consumers, 1);
+            assert_eq!(snapshot.pubsub_active_consumers_peak, 1);
+            assert_eq!(snapshot.pubsub_messages_published_total, 3);
+            assert_eq!(snapshot.pubsub_bytes_published_total, 3_072);
+            assert_eq!(snapshot.pubsub_messages_consumed_total, 2);
+            assert_eq!(snapshot.pubsub_bytes_consumed_total, 1_024);
+            assert_eq!(snapshot.pubsub_messages_published_peak_per_second, 3);
+            assert_eq!(snapshot.pubsub_messages_consumed_peak_per_second, 2);
+            assert_eq!(snapshot.subscription_changes_delivered_total, 5);
+            assert!(snapshot.pubsub_messages_published_per_second > 0.0);
+            assert!(snapshot.pubsub_messages_consumed_per_second > 0.0);
+            assert!(snapshot.pubsub_kb_published_per_second > 0.0);
+            assert!(snapshot.pubsub_kb_consumed_per_second > 0.0);
+            assert!(snapshot.subscription_changes_delivered_per_second > 0.0);
+        }
+
+        assert_eq!(pubsub_metrics_snapshot().pubsub_active_consumers, 0);
+    }
+}

--- a/backend/crates/kalamdb-observability/src/runtime_metrics.rs
+++ b/backend/crates/kalamdb-observability/src/runtime_metrics.rs
@@ -228,7 +228,9 @@ pub fn collect_runtime_metrics(start_time: Instant) -> RuntimeMetrics {
     let mut memory_virtual_mb = None;
     let mut memory_rss_gap_bytes = None;
     let mut memory_rss_gap_mb = None;
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut memory_physical_footprint_bytes = None;
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut memory_physical_footprint_mb = None;
     let mut linux_memory_breakdown = None;
     let mut memory_usage_source = "rss";

--- a/backend/crates/kalamdb-observability/src/system_stats.rs
+++ b/backend/crates/kalamdb-observability/src/system_stats.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::{
     cpu::{get_cpu_count, get_physical_cpu_count},
     health_monitor::HealthMonitor,
+    pubsub_metrics::pubsub_metrics_snapshot,
     query_metrics::query_metrics_snapshot,
     runtime_metrics::{
         collect_runtime_metrics, BUILD_DATE, GIT_BRANCH, GIT_COMMIT_HASH, SERVER_VERSION,
@@ -65,6 +66,8 @@ pub struct CacheMetrics {
     pub topic_cache_topic_count: usize,
     pub topic_cache_table_route_count: usize,
     pub topic_cache_total_routes: usize,
+    pub topic_consumer_group_count: usize,
+    pub topic_consumer_partition_count: usize,
     pub string_interner_unique_strings: usize,
 }
 
@@ -95,6 +98,7 @@ pub fn collect_system_stats(source: &impl SystemStatsSource) -> Vec<(String, Str
     let runtime = collect_runtime_metrics(source.server_start_time());
     metrics.extend(runtime.as_pairs());
     metrics.extend(query_metrics_snapshot().as_pairs());
+    metrics.extend(pubsub_metrics_snapshot().as_pairs());
     metrics.extend(storage_metrics_snapshot().as_pairs());
 
     push_metric(&mut metrics, "cpu_logical_cores", get_cpu_count());
@@ -169,6 +173,12 @@ pub fn collect_system_stats(source: &impl SystemStatsSource) -> Vec<(String, Str
         cache.topic_cache_table_route_count,
     );
     push_metric(&mut metrics, "topic_cache_total_routes", cache.topic_cache_total_routes);
+    push_metric(&mut metrics, "topic_consumer_group_count", cache.topic_consumer_group_count);
+    push_metric(
+        &mut metrics,
+        "topic_consumer_partition_count",
+        cache.topic_consumer_partition_count,
+    );
     push_metric(
         &mut metrics,
         "string_interner_unique_strings",

--- a/backend/crates/kalamdb-observability/src/trace.rs
+++ b/backend/crates/kalamdb-observability/src/trace.rs
@@ -1,0 +1,106 @@
+/// No-op span guard used when KalamDB traceability is compiled out.
+#[derive(Debug, Default)]
+pub struct NoopSpanGuard;
+
+#[macro_export]
+macro_rules! kdb_trace_span_entered {
+    ($($span:tt)*) => {{
+        #[cfg(feature = "traceability")]
+        {
+            tracing::trace_span!($($span)*).entered()
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = stringify!($($span)*);
+            $crate::NoopSpanGuard
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! kdb_debug_span_entered {
+    ($($span:tt)*) => {{
+        #[cfg(feature = "traceability")]
+        {
+            tracing::debug_span!($($span)*).entered()
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = stringify!($($span)*);
+            $crate::NoopSpanGuard
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! kdb_info_span_entered {
+    ($($span:tt)*) => {{
+        #[cfg(feature = "traceability")]
+        {
+            tracing::info_span!($($span)*).entered()
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = stringify!($($span)*);
+            $crate::NoopSpanGuard
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! kdb_await_in_info_span {
+    ($future:expr, $($span:tt)*) => {{
+        #[cfg(feature = "traceability")]
+        {
+            use tracing::Instrument as _;
+            ($future).instrument(tracing::info_span!($($span)*)).await
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = stringify!($($span)*);
+            ($future).await
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! kdb_record_current_span {
+    ($field:literal, $value:expr) => {{
+        #[cfg(feature = "traceability")]
+        {
+            tracing::Span::current().record($field, $value);
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = ($field, stringify!($value));
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! kdb_trace {
+    ($($event:tt)*) => {{
+        #[cfg(feature = "traceability")]
+        {
+            tracing::trace!($($event)*);
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = stringify!($($event)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! kdb_debug {
+    ($($event:tt)*) => {{
+        #[cfg(feature = "traceability")]
+        {
+            tracing::debug!($($event)*);
+        }
+        #[cfg(not(feature = "traceability"))]
+        {
+            let _ = stringify!($($event)*);
+        }
+    }};
+}

--- a/backend/crates/kalamdb-observability/tests/trace_macros.rs
+++ b/backend/crates/kalamdb-observability/tests/trace_macros.rs
@@ -1,0 +1,8 @@
+#[test]
+fn span_macros_are_usable_from_call_sites() {
+    let _guard = kalamdb_observability::kdb_debug_span_entered!(
+        "observability.test",
+        table_id = "default.test"
+    );
+    kalamdb_observability::kdb_debug!(table_id = "default.test", "observability test event");
+}

--- a/backend/crates/kalamdb-publisher/Cargo.toml
+++ b/backend/crates/kalamdb-publisher/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["database"]
 [dependencies]
 # Internal crates
 kalamdb-commons = { path = "../kalamdb-commons", features = ["full"] }
+kalamdb-observability = { path = "../kalamdb-observability" }
 kalamdb-row-filter = { workspace = true }
 kalamdb-store = { path = "../kalamdb-store" }
 kalamdb-system = { path = "../kalamdb-system" }

--- a/backend/crates/kalamdb-publisher/src/models.rs
+++ b/backend/crates/kalamdb-publisher/src/models.rs
@@ -6,4 +6,6 @@ pub struct TopicCacheStats {
     pub topic_count: usize,
     pub table_route_count: usize,
     pub total_routes: usize,
+    pub consumer_group_count: usize,
+    pub consumer_partition_count: usize,
 }

--- a/backend/crates/kalamdb-publisher/src/service.rs
+++ b/backend/crates/kalamdb-publisher/src/service.rs
@@ -18,6 +18,7 @@ use kalamdb_commons::{
     models::{rows::Row, ConsumerGroupId, TableId, TopicId, TopicOp, UserId},
     storage::Partition,
 };
+use kalamdb_observability::{record_pubsub_messages_consumed, record_pubsub_messages_published};
 use kalamdb_store::StorageBackend;
 use kalamdb_system::providers::{
     topic_offsets::{TopicOffset, TopicOffsetsTableProvider},
@@ -99,6 +100,22 @@ impl GroupPartitionKey {
             topic_id: topic_id.clone(),
             group_id: group_id.clone(),
             partition_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ConsumerGroupKey {
+    topic_id: TopicId,
+    group_id: ConsumerGroupId,
+}
+
+impl ConsumerGroupKey {
+    #[inline]
+    fn new(topic_id: &TopicId, group_id: &ConsumerGroupId) -> Self {
+        Self {
+            topic_id: topic_id.clone(),
+            group_id: group_id.clone(),
         }
     }
 }
@@ -211,6 +228,8 @@ pub struct TopicPublisherService {
     /// In-memory per-(topic, group, partition) claim state used to avoid
     /// duplicate delivery and to expire stale claims from crashed consumers.
     group_claim_state: DashMap<GroupPartitionKey, ClaimState>,
+    /// Known consumer groups observed from consume/ack activity or restored offsets.
+    consumer_groups: DashMap<ConsumerGroupKey, ()>,
     /// Per-(topic, partition) write locks that serialize offset allocation +
     /// RocksDB write to guarantee messages are stored in offset order.
     partition_write_locks: DashMap<TopicPartitionKey, Arc<Mutex<()>>>,
@@ -269,6 +288,7 @@ impl TopicPublisherService {
             primary_key_lookup,
             offset_allocator: OffsetAllocator::new(),
             group_claim_state: DashMap::new(),
+            consumer_groups: DashMap::new(),
             partition_write_locks: DashMap::new(),
             retained_bytes: DashMap::new(),
             visibility_timeout,
@@ -358,6 +378,7 @@ impl TopicPublisherService {
         self.route_cache.clear();
         self.offset_allocator.clear();
         self.group_claim_state.clear();
+        self.consumer_groups.clear();
         self.partition_write_locks.clear();
         self.retained_bytes.clear();
     }
@@ -390,6 +411,16 @@ impl TopicPublisherService {
             .collect();
         for key in claim_keys {
             self.group_claim_state.remove(&key);
+        }
+
+        let consumer_keys: Vec<_> = self
+            .consumer_groups
+            .iter()
+            .filter(|entry| entry.key().topic_id == *topic_id)
+            .map(|entry| entry.key().clone())
+            .collect();
+        for key in consumer_keys {
+            self.consumer_groups.remove(&key);
         }
 
         let lock_keys: Vec<_> = self
@@ -452,6 +483,10 @@ impl TopicPublisherService {
             .map_err(|e| CommonError::Internal(format!("Failed to read retained bytes: {}", e)))?;
         self.retained_bytes.insert(key, bytes);
         Ok(bytes)
+    }
+
+    fn register_consumer_group(&self, topic_id: &TopicId, group_id: &ConsumerGroupId) {
+        self.consumer_groups.insert(ConsumerGroupKey::new(topic_id, group_id), ());
     }
 
     // ===== Publishing Methods =====
@@ -548,6 +583,7 @@ impl TopicPublisherService {
                     CommonError::Internal(format!("Failed to store topic message: {}", e))
                 })?;
             self.add_retained_bytes(&entry.topic_id, partition_id, message_bytes);
+            record_pubsub_messages_published(1, message_bytes);
 
             tracing::debug!(
                 topic_name = entry.topic_id.as_str(),
@@ -736,6 +772,7 @@ impl TopicPublisherService {
                         ))
                     })?;
                 self.add_retained_bytes(&entry.topic_id, *partition_id, message_bytes);
+                record_pubsub_messages_published(row_indices.len() as u64, message_bytes);
 
                 total_published += row_indices.len();
             }
@@ -774,9 +811,13 @@ impl TopicPublisherService {
             )));
         }
 
-        self.message_store
+        let messages = self
+            .message_store
             .fetch_messages(topic_id, partition_id, offset, limit)
-            .map_err(|e| CommonError::Internal(format!("Failed to fetch messages: {}", e)))
+            .map_err(|e| CommonError::Internal(format!("Failed to fetch messages: {}", e)))?;
+        let payload_bytes = messages.iter().map(|message| message.payload.len() as u64).sum();
+        record_pubsub_messages_consumed(messages.len() as u64, payload_bytes);
+        Ok(messages)
     }
 
     /// Fetch messages for a consumer group while claiming offsets in-memory.
@@ -797,6 +838,8 @@ impl TopicPublisherService {
         if limit == 0 {
             return Ok(Vec::new());
         }
+
+        self.register_consumer_group(topic_id, group_id);
 
         let cursor_key = GroupPartitionKey::new(topic_id, group_id, partition_id);
 
@@ -861,6 +904,9 @@ impl TopicPublisherService {
                 end_exclusive,
                 claimed_at,
             });
+
+            let payload_bytes = messages.iter().map(|message| message.payload.len() as u64).sum();
+            record_pubsub_messages_consumed(messages.len() as u64, payload_bytes);
 
             return Ok(messages);
         }
@@ -1006,6 +1052,8 @@ impl TopicPublisherService {
         partition_id: u32,
         offset: u64,
     ) -> Result<()> {
+        self.register_consumer_group(topic_id, group_id);
+
         self.offset_store
             .ack_offset(topic_id, group_id, partition_id, offset)
             .map_err(|e| CommonError::Internal(format!("Failed to ack offset: {}", e)))?;
@@ -1033,6 +1081,8 @@ impl TopicPublisherService {
         partition_id: u32,
         next_offset: u64,
     ) -> Result<()> {
+        self.register_consumer_group(topic_id, group_id);
+
         self.offset_store
             .reset_offset(topic_id, group_id, partition_id, next_offset)
             .map_err(|e| CommonError::Internal(format!("Failed to reset offset: {}", e)))?;
@@ -1077,6 +1127,31 @@ impl TopicPublisherService {
             topic_count: self.route_cache.topic_count(),
             table_route_count: self.route_cache.table_route_count(),
             total_routes: self.route_cache.total_routes(),
+            consumer_group_count: self.consumer_groups.len(),
+            consumer_partition_count: self.group_claim_state.len(),
+        }
+    }
+
+    fn restore_consumer_groups_from_offsets(&self) {
+        match self.offset_store.list_offsets() {
+            Ok(offsets) => {
+                let mut restored = 0usize;
+                for offset in offsets {
+                    if self
+                        .consumer_groups
+                        .insert(ConsumerGroupKey::new(&offset.topic_id, &offset.group_id), ())
+                        .is_none()
+                    {
+                        restored += 1;
+                    }
+                }
+                if restored > 0 {
+                    log::debug!("Restored {} topic consumer groups into runtime stats", restored);
+                }
+            },
+            Err(e) => {
+                log::warn!("Failed to restore topic consumer groups from offsets: {}", e);
+            },
         }
     }
 
@@ -1140,6 +1215,8 @@ impl TopicPublisherService {
                 }
             }
         }
+
+        self.restore_consumer_groups_from_offsets();
     }
 }
 

--- a/backend/crates/kalamdb-store/Cargo.toml
+++ b/backend/crates/kalamdb-store/Cargo.toml
@@ -11,11 +11,13 @@ repository.workspace = true
 default = ["rocksdb"]
 rocksdb = ["dep:rocksdb"]
 datafusion = ["dep:datafusion"]
+traceability = ["kalamdb-observability/traceability"]
 
 [dependencies]
 # Internal crates
 kalamdb-commons = { path = "../kalamdb-commons", features = ["serde", "full"] }
 kalamdb-configs = { path = "../kalamdb-configs" }
+kalamdb-observability = { path = "../kalamdb-observability", default-features = false }
 kalamdb-sharding = { path = "../kalamdb-sharding", features = ["serde"] }
 
 rocksdb = { workspace = true, optional = true }

--- a/backend/crates/kalamdb-store/src/backends/rocksdb/backend.rs
+++ b/backend/crates/kalamdb-store/src/backends/rocksdb/backend.rs
@@ -232,12 +232,11 @@ impl RocksDBBackend {
 
 impl StorageBackend for RocksDBBackend {
     fn get(&self, partition: &Partition, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        let _span = tracing::trace_span!(
+        let _span = kalamdb_observability::kdb_trace_span_entered!(
             "rocksdb.get",
             partition = %partition.name(),
             physical_cf = physical_cf_for_partition(partition.name())
-        )
-        .entered();
+        );
         let cf = self.get_cf(partition)?;
         let physical_key = physical_key(partition.name(), key);
         self.db
@@ -246,13 +245,12 @@ impl StorageBackend for RocksDBBackend {
     }
 
     fn put(&self, partition: &Partition, key: &[u8], value: &[u8]) -> Result<()> {
-        let _span = tracing::trace_span!(
+        let _span = kalamdb_observability::kdb_trace_span_entered!(
             "rocksdb.put",
             partition = %partition.name(),
             physical_cf = physical_cf_for_partition(partition.name()),
             value_len = value.len()
-        )
-        .entered();
+        );
         let cf = self.get_cf(partition)?;
         let physical_key = physical_key(partition.name(), key);
         self.db
@@ -261,12 +259,11 @@ impl StorageBackend for RocksDBBackend {
     }
 
     fn delete(&self, partition: &Partition, key: &[u8]) -> Result<()> {
-        let _span = tracing::trace_span!(
+        let _span = kalamdb_observability::kdb_trace_span_entered!(
             "rocksdb.delete",
             partition = %partition.name(),
             physical_cf = physical_cf_for_partition(partition.name())
-        )
-        .entered();
+        );
         let cf = self.get_cf(partition)?;
         let physical_key = physical_key(partition.name(), key);
         self.db
@@ -275,7 +272,10 @@ impl StorageBackend for RocksDBBackend {
     }
 
     fn batch(&self, operations: Vec<Operation>) -> Result<()> {
-        let _span = tracing::debug_span!("rocksdb.batch", op_count = operations.len()).entered();
+        let _span = kalamdb_observability::kdb_debug_span_entered!(
+            "rocksdb.batch",
+            op_count = operations.len()
+        );
         use rocksdb::WriteBatch;
 
         if operations.is_empty() {
@@ -324,14 +324,13 @@ impl StorageBackend for RocksDBBackend {
         start_key: Option<&[u8]>,
         limit: Option<usize>,
     ) -> Result<Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + Send + '_>> {
-        let _span = tracing::trace_span!(
+        let _span = kalamdb_observability::kdb_trace_span_entered!(
             "rocksdb.scan",
             partition = %partition.name(),
             physical_cf = physical_cf_for_partition(partition.name()),
             has_prefix = prefix.is_some(),
             limit = ?limit
-        )
-        .entered();
+        );
         use rocksdb::Direction;
 
         let cf = self.get_cf(partition)?;
@@ -420,13 +419,12 @@ impl StorageBackend for RocksDBBackend {
         start_key: Option<&[u8]>,
         limit: Option<usize>,
     ) -> Result<Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + Send + '_>> {
-        let _span = tracing::trace_span!(
+        let _span = kalamdb_observability::kdb_trace_span_entered!(
             "rocksdb.scan_reverse",
             partition = %partition.name(),
             has_prefix = prefix.is_some(),
             limit = ?limit
-        )
-        .entered();
+        );
         use rocksdb::Direction;
 
         let cf = self.get_cf(partition)?;

--- a/backend/crates/kalamdb-store/src/indexed_store.rs
+++ b/backend/crates/kalamdb-store/src/indexed_store.rs
@@ -433,7 +433,10 @@ where
     /// store.insert_batch(&entries)?;  // Single atomic write for all
     /// ```
     pub fn insert_batch(&self, entries: &[(K, V)]) -> Result<()> {
-        let _span = tracing::debug_span!("store.insert_batch", count = entries.len()).entered();
+        let _span = kalamdb_observability::kdb_debug_span_entered!(
+            "store.insert_batch",
+            count = entries.len()
+        );
         if entries.is_empty() {
             return Ok(());
         }
@@ -490,8 +493,10 @@ where
         entries: &[(K, V)],
         encoded_values: Vec<Vec<u8>>,
     ) -> Result<()> {
-        let _span =
-            tracing::debug_span!("store.insert_batch_preencoded", count = entries.len()).entered();
+        let _span = kalamdb_observability::kdb_debug_span_entered!(
+            "store.insert_batch_preencoded",
+            count = entries.len()
+        );
         if entries.is_empty() {
             return Ok(());
         }

--- a/backend/crates/kalamdb-streams/src/file_store.rs
+++ b/backend/crates/kalamdb-streams/src/file_store.rs
@@ -201,8 +201,7 @@ impl FileStreamLogStore {
 
         let mut expired_dirs = Vec::new();
         visit_dirs(base_dir, |window_dir| {
-            if let Some((_window_start, window_end)) = Self::parse_window_dir(&window_dir)
-            {
+            if let Some((_window_start, window_end)) = Self::parse_window_dir(&window_dir) {
                 if window_end <= before_time {
                     expired_dirs.push(window_dir);
                 }
@@ -530,7 +529,9 @@ impl FileStreamLogStore {
                 return Ok(true);
             }
             visit_dirs(&window_dir, |shard_dir| {
-                for entry in fs::read_dir(&shard_dir).map_err(|e| StreamLogError::Io(e.to_string()))? {
+                for entry in
+                    fs::read_dir(&shard_dir).map_err(|e| StreamLogError::Io(e.to_string()))?
+                {
                     let entry = entry.map_err(|e| StreamLogError::Io(e.to_string()))?;
                     let path = entry.path();
                     if !path.is_file() {
@@ -911,7 +912,10 @@ mod tests {
             "expected stream rows to be stored directly as <user_id>.log"
         );
         assert_ne!(
-            old_path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str()),
+            old_path
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|name| name.to_str()),
             Some(user_id.as_str()),
             "expected no per-user directory in the stream file layout"
         );

--- a/backend/crates/kalamdb-tables/Cargo.toml
+++ b/backend/crates/kalamdb-tables/Cargo.toml
@@ -16,6 +16,7 @@ kalamdb-commons = { path = "../kalamdb-commons", features = ["full"] }
 kalamdb-macros = { path = "../kalamdb-macros" }
 kalamdb-store = { path = "../kalamdb-store" }
 kalamdb-filestore = { path = "../kalamdb-filestore" }
+kalamdb-observability = { path = "../kalamdb-observability", default-features = false }
 kalamdb-system = { path = "../kalamdb-system" }
 kalamdb-streams = { path = "../kalamdb-streams" }
 kalamdb-sharding = { path = "../kalamdb-sharding" }
@@ -57,3 +58,6 @@ tempfile = { workspace = true }
 [lib]
 name = "kalamdb_tables"
 path = "src/lib.rs"
+
+[features]
+traceability = ["kalamdb-observability/traceability"]

--- a/backend/crates/kalamdb-tables/src/shared_tables/shared_table_provider.rs
+++ b/backend/crates/kalamdb-tables/src/shared_tables/shared_table_provider.rs
@@ -106,19 +106,18 @@ impl SharedTableProvider {
             })
             .collect();
         let backend = store.backend().clone();
-        let vector_stores: HashMap<String, Arc<SharedVectorHotStore>> = vector_columns
-            .iter()
-            .map(|(column_name, _)| {
-                (
-                    column_name.clone(),
-                    Arc::new(new_indexed_shared_vector_hot_store(
-                        backend.clone(),
-                        core.table_id(),
-                        column_name,
-                    )),
-                )
-            })
-            .collect();
+        let mut vector_stores: HashMap<String, Arc<SharedVectorHotStore>> =
+            HashMap::with_capacity(vector_columns.len());
+        for (column_name, _) in &vector_columns {
+            vector_stores.insert(
+                column_name.clone(),
+                Arc::new(new_indexed_shared_vector_hot_store(
+                    backend.clone(),
+                    core.table_id(),
+                    column_name,
+                )),
+            );
+        }
 
         Self {
             core,
@@ -1522,8 +1521,8 @@ impl SharedTableProvider {
 
         if validate_unique_pk {
             let pk_name = self.primary_key_field_name();
-            let mut pk_values_to_check: Vec<(String, ScalarValue)> = Vec::new();
-            let mut seen_batch_pks = HashSet::new();
+            let mut pk_values_to_check: Vec<(String, ScalarValue)> = Vec::with_capacity(row_count);
+            let mut seen_batch_pks = HashSet::with_capacity(row_count);
             for row_data in &coerced_rows {
                 if let Some(pk_value) = row_data.get(pk_name) {
                     if !matches!(pk_value, ScalarValue::Null) {
@@ -1542,12 +1541,11 @@ impl SharedTableProvider {
             }
 
             if !pk_values_to_check.is_empty() {
-                let pk_prefixes: Vec<(String, Vec<u8>)> = pk_values_to_check
-                    .iter()
-                    .map(|(pk_str, pk_value)| {
-                        (pk_str.clone(), self.pk_index.build_prefix_for_pk(pk_value))
-                    })
-                    .collect();
+                let mut pk_prefixes: Vec<(String, Vec<u8>)> =
+                    Vec::with_capacity(pk_values_to_check.len());
+                for (pk_str, pk_value) in &pk_values_to_check {
+                    pk_prefixes.push((pk_str.clone(), self.pk_index.build_prefix_for_pk(pk_value)));
+                }
 
                 let store = self.store.clone();
                 let hot_duplicate =
@@ -1607,21 +1605,19 @@ impl SharedTableProvider {
             KalamDbError::InvalidOperation(format!("SeqId batch generation failed: {}", e))
         })?;
 
-        let mut shared_rows: Vec<SharedTableRow> = Vec::with_capacity(row_count);
-        let mut row_keys: Vec<SharedTableRowId> = Vec::with_capacity(row_count);
+        let mut entries: Vec<(SharedTableRowId, SharedTableRow)> = Vec::with_capacity(row_count);
 
         for (row_data, seq_id) in coerced_rows.into_iter().zip(seq_ids.into_iter()) {
-            row_keys.push(seq_id);
-            shared_rows.push(SharedTableRow {
-                _seq: seq_id,
-                _commit_seq: commit_seq,
-                _deleted: false,
-                fields: row_data,
-            });
+            entries.push((
+                seq_id,
+                SharedTableRow {
+                    _seq: seq_id,
+                    _commit_seq: commit_seq,
+                    _deleted: false,
+                    fields: row_data,
+                },
+            ));
         }
-
-        let entries: Vec<(SharedTableRowId, SharedTableRow)> =
-            row_keys.iter().copied().zip(shared_rows.into_iter()).collect();
 
         let store = self.store.clone();
 
@@ -1678,8 +1674,8 @@ impl SharedTableProvider {
         log::debug!(
             "Batch inserted {} shared table rows with _seq range [{}, {}]",
             row_count,
-            row_keys.first().map(|k| k.as_i64()).unwrap_or(0),
-            row_keys.last().map(|k| k.as_i64()).unwrap_or(0)
+            entries.first().map(|(k, _)| k.as_i64()).unwrap_or(0),
+            entries.last().map(|(k, _)| k.as_i64()).unwrap_or(0)
         );
 
         Ok(entries)

--- a/backend/crates/kalamdb-tables/src/user_tables/user_table_provider.rs
+++ b/backend/crates/kalamdb-tables/src/user_tables/user_table_provider.rs
@@ -137,19 +137,18 @@ impl UserTableProvider {
             })
             .collect();
         let backend = store.backend().clone();
-        let vector_stores: HashMap<String, Arc<UserVectorHotStore>> = vector_columns
-            .iter()
-            .map(|(column_name, _)| {
-                (
-                    column_name.clone(),
-                    Arc::new(new_indexed_user_vector_hot_store(
-                        backend.clone(),
-                        core.table_id(),
-                        column_name,
-                    )),
-                )
-            })
-            .collect();
+        let mut vector_stores: HashMap<String, Arc<UserVectorHotStore>> =
+            HashMap::with_capacity(vector_columns.len());
+        for (column_name, _) in &vector_columns {
+            vector_stores.insert(
+                column_name.clone(),
+                Arc::new(new_indexed_user_vector_hot_store(
+                    backend.clone(),
+                    core.table_id(),
+                    column_name,
+                )),
+            );
+        }
 
         if log::log_enabled!(log::Level::Debug) {
             let field_names: Vec<_> = core.schema().fields().iter().map(|f| f.name()).collect();
@@ -297,8 +296,11 @@ impl UserTableProvider {
         I: IntoIterator<Item = &'a Row>,
     {
         let pk_name = self.primary_key_field_name();
-        let mut pk_values_to_check: Vec<(String, ScalarValue)> = Vec::new();
-        let mut seen_batch_pks = HashSet::new();
+        let rows = rows.into_iter();
+        let (lower_bound, upper_bound) = rows.size_hint();
+        let capacity = upper_bound.unwrap_or(lower_bound);
+        let mut pk_values_to_check: Vec<(String, ScalarValue)> = Vec::with_capacity(capacity);
+        let mut seen_batch_pks = HashSet::with_capacity(capacity);
 
         for row_data in rows {
             if let Some(pk_value) = row_data.get(pk_name) {
@@ -321,12 +323,11 @@ impl UserTableProvider {
             return Ok(());
         }
 
-        let pk_prefixes: Vec<(String, Vec<u8>)> = pk_values_to_check
-            .iter()
-            .map(|(pk_str, pk_value)| {
-                (pk_str.clone(), self.pk_index.build_prefix_for_pk(user_id, pk_value))
-            })
-            .collect();
+        let mut pk_prefixes: Vec<(String, Vec<u8>)> = Vec::with_capacity(pk_values_to_check.len());
+        for (pk_str, pk_value) in &pk_values_to_check {
+            pk_prefixes
+                .push((pk_str.clone(), self.pk_index.build_prefix_for_pk(user_id, pk_value)));
+        }
 
         let store = self.store.clone();
         let hot_duplicate =
@@ -417,23 +418,23 @@ impl UserTableProvider {
             KalamDbError::InvalidOperation(format!("SeqId batch generation failed: {}", e))
         })?;
 
-        let mut user_rows: Vec<UserTableRow> = Vec::with_capacity(row_count);
-        let mut row_keys: Vec<UserTableRowId> = Vec::with_capacity(row_count);
+        let mut entries: Vec<(UserTableRowId, UserTableRow)> = Vec::with_capacity(row_count);
 
         for (row_data, seq_id) in coerced_rows.into_iter().zip(seq_ids.into_iter()) {
-            row_keys.push(UserTableRowId::new(user_id.clone(), seq_id));
-            user_rows.push(UserTableRow {
-                user_id: user_id.clone(),
-                _seq: seq_id,
-                _commit_seq: commit_seq,
-                _deleted: false,
-                fields: row_data,
-            });
+            let row_key = UserTableRowId::new(user_id.clone(), seq_id);
+            entries.push((
+                row_key,
+                UserTableRow {
+                    user_id: user_id.clone(),
+                    _seq: seq_id,
+                    _commit_seq: commit_seq,
+                    _deleted: false,
+                    fields: row_data,
+                },
+            ));
         }
 
         let store = self.store.clone();
-        let entries: Vec<(UserTableRowId, UserTableRow)> =
-            row_keys.iter().cloned().zip(user_rows.into_iter()).collect();
 
         let entries = tokio::task::spawn_blocking(
             move || -> Result<Vec<(UserTableRowId, UserTableRow)>, KalamDbError> {
@@ -482,8 +483,8 @@ impl UserTableProvider {
             "Batch inserted {} user table rows for user {} with _seq range [{}, {}]",
             row_count,
             user_id.as_str(),
-            row_keys.first().map(|k| k.seq.as_i64()).unwrap_or(0),
-            row_keys.last().map(|k| k.seq.as_i64()).unwrap_or(0)
+            entries.first().map(|(k, _)| k.seq.as_i64()).unwrap_or(0),
+            entries.last().map(|(k, _)| k.seq.as_i64()).unwrap_or(0)
         );
 
         Ok(entries)

--- a/backend/crates/kalamdb-tables/src/utils/datafusion_dml.rs
+++ b/backend/crates/kalamdb-tables/src/utils/datafusion_dml.rs
@@ -148,7 +148,7 @@ pub async fn collect_input_rows(
     state: &dyn Session,
     input: Arc<dyn ExecutionPlan>,
 ) -> DataFusionResult<Vec<Row>> {
-    tracing::debug!("dml.collect_input_rows");
+    kalamdb_observability::kdb_debug!("dml.collect_input_rows");
     if let Some(rows) = try_collect_memory_input_rows(input.as_ref())? {
         return Ok(rows);
     }
@@ -453,9 +453,11 @@ fn evaluate_expr_against_batch(
 
 fn record_batches_to_rows(batches: &[RecordBatch]) -> DataFusionResult<Vec<Row>> {
     let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-    let _span =
-        tracing::debug_span!("record_batches_to_rows", total_rows, batch_count = batches.len())
-            .entered();
+    let _span = kalamdb_observability::kdb_debug_span_entered!(
+        "record_batches_to_rows",
+        total_rows,
+        batch_count = batches.len()
+    );
     let mut rows = Vec::with_capacity(total_rows);
 
     for batch in batches {

--- a/backend/crates/kalamdb-tables/src/utils/mod.rs
+++ b/backend/crates/kalamdb-tables/src/utils/mod.rs
@@ -13,7 +13,7 @@ pub mod datafusion_dml;
 pub mod dml_provider;
 pub mod parquet;
 pub mod pk; // Primary key utilities and existence checking
-pub mod pk_utils; // Phase 13.7: Shared PK extraction and bloom filter utilities
+pub mod pk_utils; // Shared PK extraction utilities
 pub mod row_utils;
 pub mod unified_dml; // Phase 13.6: Moved from tables/
 pub mod vector_staging;

--- a/backend/crates/kalamdb-tables/src/utils/vector_staging.rs
+++ b/backend/crates/kalamdb-tables/src/utils/vector_staging.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use futures_util::future::try_join_all;
 use kalamdb_commons::{models::rows::Row, StorageKey, TableId};
 use kalamdb_store::IndexedEntityStore;
 use kalamdb_system::VectorMetric;
@@ -23,7 +24,10 @@ where
     FRow: FnMut(&T) -> &Row,
     FKey: FnMut(&T, &str) -> K,
 {
-    let mut ops_by_column: HashMap<String, Vec<(K, VectorHotOp)>> = HashMap::new();
+    let entries = entries.into_iter();
+    let (entry_count, _) = entries.size_hint();
+    let mut ops_by_column: HashMap<String, Vec<(K, VectorHotOp)>> =
+        HashMap::with_capacity(vector_columns.len());
 
     for entry in entries {
         let row = row_for(&entry);
@@ -37,19 +41,22 @@ where
                 continue;
             };
 
-            ops_by_column.entry(column_name.clone()).or_default().push((
-                key_for(&entry, pk.as_str()),
-                VectorHotOp::new(
-                    table_id.clone(),
-                    column_name.clone(),
-                    pk.clone(),
-                    VectorHotOpType::Upsert,
-                    Some(vector),
-                    None,
-                    *dimensions,
-                    VectorMetric::Cosine,
-                ),
-            ));
+            ops_by_column
+                .entry(column_name.clone())
+                .or_insert_with(|| Vec::with_capacity(entry_count))
+                .push((
+                    key_for(&entry, pk.as_str()),
+                    VectorHotOp::new(
+                        table_id.clone(),
+                        column_name.clone(),
+                        pk.clone(),
+                        VectorHotOpType::Upsert,
+                        Some(vector),
+                        None,
+                        *dimensions,
+                        VectorMetric::Cosine,
+                    ),
+                ));
         }
     }
 
@@ -65,22 +72,26 @@ pub(crate) fn build_vector_delete_ops<K, FKey>(
 where
     FKey: FnMut(&str) -> K,
 {
-    let mut ops_by_column: HashMap<String, Vec<(K, VectorHotOp)>> = HashMap::new();
+    let mut ops_by_column: HashMap<String, Vec<(K, VectorHotOp)>> =
+        HashMap::with_capacity(vector_columns.len());
 
     for (column_name, dimensions) in vector_columns {
-        ops_by_column.entry(column_name.clone()).or_default().push((
-            key_for(pk),
-            VectorHotOp::new(
-                table_id.clone(),
-                column_name.clone(),
-                pk.to_string(),
-                VectorHotOpType::Delete,
-                None,
-                None,
-                *dimensions,
-                VectorMetric::Cosine,
-            ),
-        ));
+        ops_by_column.insert(
+            column_name.clone(),
+            vec![(
+                key_for(pk),
+                VectorHotOp::new(
+                    table_id.clone(),
+                    column_name.clone(),
+                    pk.to_string(),
+                    VectorHotOpType::Delete,
+                    None,
+                    None,
+                    *dimensions,
+                    VectorMetric::Cosine,
+                ),
+            )],
+        );
     }
 
     ops_by_column
@@ -94,20 +105,26 @@ pub(crate) async fn stage_vector_ops_by_column<K>(
 where
     K: StorageKey + Clone + Send + Sync + 'static,
 {
-    for (column_name, ops) in ops_by_column {
+    let futures = ops_by_column.into_iter().map(|(column_name, ops)| {
         let store = vector_stores.get(&column_name).ok_or_else(|| {
             KalamDbError::InvalidOperation(format!(
                 "Missing cached vector store for column '{}'",
                 column_name
             ))
         })?;
-        store.insert_batch_async(ops).await.map_err(|error| {
-            KalamDbError::InvalidOperation(format!(
-                "Failed to {} ops for column '{}': {}",
-                action, column_name, error
-            ))
-        })?;
-    }
+        let store = Arc::clone(store);
+        Ok(async move {
+            store.insert_batch_async(ops).await.map_err(|error| {
+                KalamDbError::InvalidOperation(format!(
+                    "Failed to {} ops for column '{}': {}",
+                    action, column_name, error
+                ))
+            })
+        })
+    });
+
+    let futures = futures.collect::<Result<Vec<_>, KalamDbError>>()?;
+    try_join_all(futures).await?;
 
     Ok(())
 }

--- a/backend/server.toml
+++ b/backend/server.toml
@@ -17,7 +17,7 @@ port = 2900
 # Set this when browsers reach KalamDB through a public hostname or reverse proxy.
 # Example: "https://db.example.com"
 # Empty = use "http://localhost:{port}"
-public_origin = ""
+public_origin = "http://localhost:2900"
 
 # Number of worker threads (0 = number of CPU cores)
 # Each worker adds ~2 MB idle RSS. For development, 4 workers is sufficient.

--- a/backend/tests/common/testserver/flush_helpers.rs
+++ b/backend/tests/common/testserver/flush_helpers.rs
@@ -77,6 +77,7 @@ pub async fn execute_flush_synchronously(
         cached_table.schema_version,
         cached_table.bloom_filter_columns().to_vec(),
         cached_table.indexed_columns().to_vec(),
+        cached_table.table.table_options.parquet_compression(),
     );
     let scan_batch_size = server.app_context.config().flush.flush_batch_size;
     let scope_hook = Arc::new(NoopFlushScopeHook);
@@ -149,6 +150,7 @@ pub async fn execute_shared_flush_synchronously(
         cached_table.schema_version,
         cached_table.bloom_filter_columns().to_vec(),
         cached_table.indexed_columns().to_vec(),
+        cached_table.table.table_options.parquet_compression(),
     );
     let scan_batch_size = server.app_context.config().flush.flush_batch_size;
     let scope_hook = Arc::new(NoopFlushScopeHook);

--- a/cli/run-tests.sh
+++ b/cli/run-tests.sh
@@ -780,9 +780,9 @@ ensure_dex_for_oidc_tests() {
 
 npm_install_dir() {
     if [ -f package-lock.json ]; then
-        npm ci --no-audit --no-fund
+        npm ci --include=dev --no-audit --no-fund
     else
-        npm install --no-audit --no-fund --no-package-lock
+        npm install --include=dev --no-audit --no-fund --no-package-lock
     fi
 }
 

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -2222,6 +2222,7 @@ pub async fn execute_sql_via_http_as(
     let response = client
         .post(format!("{}/v1/api/sql", base_url))
         .header("Authorization", format!("Bearer {}", token))
+        .timeout(Duration::from_secs(15))
         .json(&json!({ "sql": sql }))
         .send()
         .await?;

--- a/cli/tests/smoke.rs
+++ b/cli/tests/smoke.rs
@@ -123,10 +123,10 @@ mod smoke_test_backup_restore;
 mod smoke_test_datatype_preservation;
 #[path = "smoke/ddl/smoke_test_ddl_alter.rs"]
 mod smoke_test_ddl_alter;
-#[path = "smoke/ddl/smoke_test_table_option_alters.rs"]
-mod smoke_test_table_option_alters;
 #[path = "smoke/ddl/smoke_test_export_user_data.rs"]
 mod smoke_test_export_user_data;
+#[path = "smoke/ddl/smoke_test_table_option_alters.rs"]
+mod smoke_test_table_option_alters;
 
 // DML tests
 #[path = "smoke/dml/smoke_test_dml_extended.rs"]

--- a/cli/tests/smoke/ddl/smoke_test_table_option_alters.rs
+++ b/cli/tests/smoke/ddl/smoke_test_table_option_alters.rs
@@ -33,7 +33,8 @@ fn smoke_test_alter_user_table_options_preserves_query_dml_and_flush() {
 
     println!("🧪 Testing ALTER TABLE SET TBLPROPERTIES for USER tables");
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
+    let _ =
+        execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
     execute_sql_as_root_via_client(&format!("CREATE NAMESPACE {}", namespace))
         .expect("Failed to create namespace");
 
@@ -60,7 +61,7 @@ fn smoke_test_alter_user_table_options_preserves_query_dml_and_flush() {
     .expect("Failed to insert initial user-table row");
 
     let alter_sql = format!(
-        "ALTER TABLE {} SET TBLPROPERTIES (USE_USER_STORAGE = false, FLUSH_POLICY = 'rows:50,interval:120', COMPRESSION = 'lz4')",
+        "ALTER TABLE {} SET TBLPROPERTIES (USE_USER_STORAGE = false, FLUSH_POLICY = 'rows:50,interval:120', COMPRESSION = 'none')",
         full_table
     );
     execute_sql_as_root_via_client(&alter_sql).expect("Failed to alter user table options");
@@ -78,7 +79,14 @@ fn smoke_test_alter_user_table_options_preserves_query_dml_and_flush() {
     .expect("Failed to query latest user table schema row");
     assert_contains_all_case_insensitive(
         &latest_output,
-        &["false", "lz4", "row_limit", "50", "interval_seconds", "120"],
+        &[
+            "false",
+            "none",
+            "row_limit",
+            "50",
+            "interval_seconds",
+            "120",
+        ],
         "latest user table schema options",
     );
 
@@ -87,11 +95,8 @@ fn smoke_test_alter_user_table_options_preserves_query_dml_and_flush() {
         full_table
     ))
     .expect("Failed to insert second user-table row after ALTER");
-    execute_sql_as_root_via_client(&format!(
-        "UPDATE {} SET visits = 15 WHERE id = 1",
-        full_table
-    ))
-    .expect("Failed to update user-table row after ALTER");
+    execute_sql_as_root_via_client(&format!("UPDATE {} SET visits = 15 WHERE id = 1", full_table))
+        .expect("Failed to update user-table row after ALTER");
 
     let pre_flush = wait_for_query_contains_with(
         &format!("SELECT * FROM {} ORDER BY id", full_table),
@@ -140,7 +145,8 @@ fn smoke_test_alter_user_table_options_preserves_query_dml_and_flush() {
         "user table rows after post-flush insert",
     );
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
+    let _ =
+        execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
 }
 
 #[ntest::timeout(180000)]
@@ -157,7 +163,8 @@ fn smoke_test_alter_shared_table_options_preserves_query_dml_and_flush() {
 
     println!("🧪 Testing ALTER TABLE SET TBLPROPERTIES for SHARED tables");
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
+    let _ =
+        execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
     execute_sql_as_root_via_client(&format!("CREATE NAMESPACE {}", namespace))
         .expect("Failed to create namespace");
 
@@ -264,7 +271,8 @@ fn smoke_test_alter_shared_table_options_preserves_query_dml_and_flush() {
         "shared table rows after post-flush insert",
     );
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
+    let _ =
+        execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
 }
 
 #[ntest::timeout(180000)]
@@ -281,7 +289,8 @@ fn smoke_test_alter_stream_table_options_preserves_query_and_dml() {
 
     println!("🧪 Testing ALTER TABLE SET TBLPROPERTIES for STREAM tables");
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
+    let _ =
+        execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
     execute_sql_as_root_via_client(&format!("CREATE NAMESPACE {}", namespace))
         .expect("Failed to create namespace");
 
@@ -294,13 +303,29 @@ fn smoke_test_alter_stream_table_options_preserves_query_and_dml() {
             TYPE = 'STREAM',
             TTL_SECONDS = 60,
             EVICTION_STRATEGY = 'time_based',
-            MAX_STREAM_SIZE_BYTES = 1024,
-            COMPRESSION = 'snappy'
+            MAX_STREAM_SIZE_BYTES = 1024
         )"#,
         full_table
     );
     execute_sql_as_root_via_client(&create_sql).expect("Failed to create stream table");
     wait_for_schema_history(&namespace, &table, 1, 1, "stream create");
+
+    let invalid_stream_create = format!(
+        r#"CREATE TABLE {}.invalid_stream_compression (
+            event_id BIGINT PRIMARY KEY,
+            event_type TEXT NOT NULL
+        ) WITH (
+            TYPE = 'STREAM',
+            TTL_SECONDS = 60,
+            COMPRESSION = 'snappy'
+        )"#,
+        namespace
+    );
+    assert_sql_rejected_with(
+        &invalid_stream_create,
+        "COMPRESSION is only supported for USER and SHARED tables",
+        "stream CREATE with compression",
+    );
 
     execute_sql_as_root_via_client(&format!(
         "INSERT INTO {} (event_id, event_type, payload) VALUES (1, 'created', 'before alter')",
@@ -309,10 +334,16 @@ fn smoke_test_alter_stream_table_options_preserves_query_and_dml() {
     .expect("Failed to insert initial stream-table row");
 
     let alter_sql = format!(
-        "ALTER TABLE {} SET TBLPROPERTIES (TTL_SECONDS = 120, EVICTION_STRATEGY = 'hybrid', MAX_STREAM_SIZE_BYTES = 4096, COMPRESSION = 'lz4')",
+        "ALTER TABLE {} SET TBLPROPERTIES (TTL_SECONDS = 120, EVICTION_STRATEGY = 'hybrid', MAX_STREAM_SIZE_BYTES = 4096)",
         full_table
     );
     execute_sql_as_root_via_client(&alter_sql).expect("Failed to alter stream table options");
+
+    assert_sql_rejected_with(
+        &format!("ALTER TABLE {} SET TBLPROPERTIES (COMPRESSION = 'zstd')", full_table),
+        "COMPRESSION is not supported for STREAM tables",
+        "stream ALTER with compression",
+    );
 
     let history = wait_for_schema_history(&namespace, &table, 2, 2, "stream alter");
     assert_eq!(row_i64(&history[0], "schema_version"), Some(1));
@@ -327,7 +358,13 @@ fn smoke_test_alter_stream_table_options_preserves_query_and_dml() {
     .expect("Failed to query latest stream table schema row");
     assert_contains_all_case_insensitive(
         &latest_output,
-        &["ttl_seconds", "120", "hybrid", "max_stream_size_bytes", "4096", "lz4"],
+        &[
+            "ttl_seconds",
+            "120",
+            "hybrid",
+            "max_stream_size_bytes",
+            "4096",
+        ],
         "latest stream table schema options",
     );
 
@@ -365,7 +402,8 @@ fn smoke_test_alter_stream_table_options_preserves_query_and_dml() {
         "stream table rows after rejected flush",
     );
 
-    let _ = execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
+    let _ =
+        execute_sql_as_root_via_client(&format!("DROP NAMESPACE IF EXISTS {} CASCADE", namespace));
 }
 
 fn wait_for_schema_history(
@@ -384,19 +422,15 @@ fn wait_for_schema_history(
     loop {
         let output = execute_sql_as_root_via_client_json(&query)
             .unwrap_or_else(|err| panic!("{}: failed to query system.schemas: {}", context, err));
-        let json: Value = serde_json::from_str(&output)
-            .unwrap_or_else(|err| panic!("{}: failed to parse JSON output: {} ({})", context, err, output));
+        let json: Value = serde_json::from_str(&output).unwrap_or_else(|err| {
+            panic!("{}: failed to parse JSON output: {} ({})", context, err, output)
+        });
         let rows = get_rows_as_hashmaps(&json).unwrap_or_default();
 
         let matches = rows.len() == expected_rows
-            && rows
-                .last()
-                .and_then(|row| row_i64(row, "schema_version"))
+            && rows.last().and_then(|row| row_i64(row, "schema_version"))
                 == Some(expected_latest_version)
-            && rows
-                .last()
-                .and_then(|row| row_bool(row, "is_latest"))
-                == Some(true);
+            && rows.last().and_then(|row| row_bool(row, "is_latest")) == Some(true);
 
         if matches {
             return rows;
@@ -452,6 +486,31 @@ fn assert_contains_all_case_insensitive(output: &str, needles: &[&str], context:
     }
 }
 
+fn assert_sql_rejected_with(sql: &str, expected: &str, context: &str) {
+    match execute_sql_as_root_via_client(sql) {
+        Err(err) => {
+            let message = err.to_string();
+            assert!(
+                message.to_ascii_lowercase().contains(&expected.to_ascii_lowercase()),
+                "{}: expected rejection containing '{}', got error: {}",
+                context,
+                expected,
+                err
+            );
+        },
+        Ok(output) => {
+            let message = output.to_ascii_lowercase();
+            assert!(
+                message.contains("error") && message.contains(&expected.to_ascii_lowercase()),
+                "{}: expected rejection containing '{}', got success output: {}",
+                context,
+                expected,
+                output
+            );
+        },
+    }
+}
+
 fn flush_table_and_assert(
     full_table: &str,
     namespace: &str,
@@ -459,10 +518,12 @@ fn flush_table_and_assert(
     is_user_table: bool,
     context: &str,
 ) {
-    let flush_output = execute_sql_as_root_via_client(&format!("STORAGE FLUSH TABLE {}", full_table))
-        .unwrap_or_else(|err| panic!("{}: flush command failed: {}", context, err));
-    let job_id = parse_job_id_from_flush_output(&flush_output)
-        .unwrap_or_else(|err| panic!("{}: failed to parse flush job id from '{}': {}", context, flush_output, err));
+    let flush_output =
+        execute_sql_as_root_via_client(&format!("STORAGE FLUSH TABLE {}", full_table))
+            .unwrap_or_else(|err| panic!("{}: flush command failed: {}", context, err));
+    let job_id = parse_job_id_from_flush_output(&flush_output).unwrap_or_else(|err| {
+        panic!("{}: failed to parse flush job id from '{}': {}", context, flush_output, err)
+    });
     let timeout = if is_cluster_mode() {
         FLUSH_WAIT_TIMEOUT + Duration::from_secs(15)
     } else {

--- a/docs/architecture/decisions/adr-006-flush-execution.md
+++ b/docs/architecture/decisions/adr-006-flush-execution.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted  
 **Date**: 2025-10-22  
-**Updated**: 2026-05-24
+**Updated**: 2026-05-27
 **Related**: ADR-001 (Table-per-User), ADR-005 (RocksDB Metadata Only), ADR-007 (Storage Registry)
 
 ## Context
@@ -51,9 +51,14 @@ This keeps the cold write path simple while preserving correct MVCC visibility.
 
 1. Mark the manifest as `syncing`.
 2. Allocate the next `batch-N.parquet` name from `manifest.last_sequence_number`.
-3. Write `batch-N.parquet.tmp`.
+3. Write `batch-N.parquet.tmp` with the table's configured Parquet compression (`none`, `snappy`,
+   or `zstd`).
 4. Atomically rename it to `batch-N.parquet`.
 5. Compute `_seq` range, row count, schema version, size, and indexed-column stats.
+
+Parquet Bloom filters are emitted only for primary key columns. `_seq` stays in manifest stats for
+range pruning, so flush avoids maintaining an extra Bloom filter for a column that is already handled
+by segment-level sequence metadata.
 
 This keeps batch numbering serialized per scope and prevents overlapping flushes from racing the
 manifest append.
@@ -121,7 +126,8 @@ Compaction runs in two phases:
    and `_deleted`.
 2. Inspect older segments to decide which delete tombstones must be preserved to continue masking
    older cold rows.
-3. Stream only winning rows into `compact-<uuid>.parquet.tmp`.
+3. Stream only winning rows into `compact-<uuid>.parquet.tmp` using the same Parquet compression
+    configured on the USER/SHARED table.
 4. Rename to `compact-<uuid>.parquet`.
 
 The old manifest remains readable during this work.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -13,6 +13,25 @@ The observability crate is now the source of truth for:
 - manifest/parquet activity and flush counters
 - open-file breakdowns used by health logging and `system.stats`
 
+## Traceability feature gate
+
+Runtime metrics and dashboard counters are separate from tracing spans. The admin UI relies on
+`system.stats`, so metrics remain enabled by default through `kalamdb-observability`'s `metrics`
+feature and are still compiled when traceability is disabled.
+
+Tracing spans and trace/debug events that sit on query, RocksDB, row serialization, DML collection,
+manifest, and Parquet hot paths must go through the `kalamdb-observability` macro facade instead of
+calling `tracing::*` directly. The server's default feature set includes `traceability` for current
+developer behavior. Production builds that want dashboard metrics without hot-path tracing can use:
+
+```bash
+cd backend && cargo build --release --no-default-features --features embedded-ui,mimalloc
+```
+
+The macros compile to no-ops without evaluating span fields or timing expressions when
+`traceability` is not enabled. This keeps the observability seam deep: callers express the span/event
+once, while the crate controls whether it becomes a `tracing` span or disappears at compile time.
+
 Query metrics are lock-free atomics on the hot path:
 
 - `queries_total`
@@ -29,6 +48,27 @@ Query metrics are lock-free atomics on the hot path:
 - `avg_query_latency_ms`
 
 The query rate is a bounded rolling window, and average latency is derived from accumulated execution time. Queries against `system.*` and `dba.*` tables are excluded from these counters so dashboard and administrative reads do not inflate user workload metrics. There is no background writer or persisted `dba` metrics table.
+
+Pub/sub and live-subscription metrics are also lock-free atomics or in-memory cache counts; dashboard reads do not scan topic message storage:
+
+- `pubsub_messages_published_total`
+- `pubsub_messages_published_per_second`
+- `pubsub_messages_published_peak_per_second`
+- `pubsub_bytes_published_total`
+- `pubsub_kb_published_per_second`
+- `pubsub_messages_consumed_total`
+- `pubsub_messages_consumed_per_second`
+- `pubsub_messages_consumed_peak_per_second`
+- `pubsub_bytes_consumed_total`
+- `pubsub_kb_consumed_per_second`
+- `pubsub_active_consumers`
+- `pubsub_active_consumers_peak`
+- `subscription_changes_delivered_total`
+- `subscription_changes_delivered_per_second`
+- `topic_consumer_group_count`
+- `topic_consumer_partition_count`
+
+Publish and consume counters are recorded only after successful topic writes or reads. Active consumer counts wrap HTTP and SQL consume requests, while consumer group totals come from the topic publisher's runtime state and restored offset metadata.
 
 Storage-adjacent observability counters are also maintained as lightweight atomics in `kalamdb-observability` and updated from the owning write paths:
 

--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -76,7 +76,7 @@ CREATE [USER|SHARED|STREAM] TABLE [IF NOT EXISTS] [<namespace>.]<table_name> (
   ACCESS_LEVEL = '<PUBLIC|PRIVATE|RESTRICTED|DBA>',
   EVICTION_STRATEGY = '<time_based|size_based|hybrid>',
   MAX_STREAM_SIZE_BYTES = <bytes>,
-  COMPRESSION = '<snappy|none|lz4|zstd>'
+  COMPRESSION = '<none|snappy|zstd>'
 )];
 ```
 
@@ -84,7 +84,14 @@ Table options are type-specific:
 
 - `USER`: `STORAGE_ID`, `USE_USER_STORAGE`, `FLUSH_POLICY`, `COMPRESSION`
 - `SHARED`: `STORAGE_ID`, `ACCESS_LEVEL`, `FLUSH_POLICY`, `COMPRESSION`
-- `STREAM`: `TTL_SECONDS`, `EVICTION_STRATEGY`, `MAX_STREAM_SIZE_BYTES`, `COMPRESSION`
+- `STREAM`: `TTL_SECONDS`, `EVICTION_STRATEGY`, `MAX_STREAM_SIZE_BYTES`
+
+`COMPRESSION` accepts only `none`, `snappy`, and `zstd`, and is valid only for `USER` and `SHARED`
+tables. It controls the Parquet codec used when table data is flushed or compacted into
+cold-storage segments. `none` writes uncompressed Parquet pages, `snappy` is the default fast codec,
+and `zstd` uses Zstandard level 1 for better density with modest CPU cost. This setting is separate
+from WebSocket gzip and RocksDB compression. `STREAM` tables use hot stream log storage and do not
+accept table Parquet compression.
 
 Examples:
 
@@ -120,8 +127,7 @@ CREATE STREAM TABLE app.events (
 ) WITH (
   TTL_SECONDS = 30,
   EVICTION_STRATEGY = 'hybrid',
-  MAX_STREAM_SIZE_BYTES = 1048576,
-  COMPRESSION = 'lz4'
+  MAX_STREAM_SIZE_BYTES = 1048576
 );
 ```
 

--- a/ui/src/components/audit/AuditLogList.tsx
+++ b/ui/src/components/audit/AuditLogList.tsx
@@ -191,27 +191,23 @@ function getActionColor(action: string): string {
           <div className="flex items-center gap-1">
             <Button
               variant="outline"
-              size="icon"
-              className="h-8 w-8"
+              size="icon-sm"
               disabled={page === 0}
               onClick={() => handlePageChange(page - 1)}
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
-            <span className="text-sm text-muted-foreground px-2">
-              {page + 1}
-            </span>
+            <span className="text-sm text-muted-foreground px-2">{page + 1}</span>
             <Button
               variant="outline"
-              size="icon"
-              className="h-8 w-8"
+              size="icon-sm"
               disabled={logs.length < pageSize}
               onClick={() => handlePageChange(page + 1)}
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
           </div>
-          <Button variant="outline" size="icon" className="h-8 w-8" onClick={handleRefresh} disabled={isLoading} aria-label="Refresh audit logs">
+          <Button variant="outline" size="icon-sm" onClick={handleRefresh} disabled={isLoading} aria-label="Refresh audit logs">
             <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
           </Button>
         </div>

--- a/ui/src/components/auth/AuthSplitLayout.tsx
+++ b/ui/src/components/auth/AuthSplitLayout.tsx
@@ -36,7 +36,7 @@ export default function AuthSplitLayout({
             <div className="w-full max-w-md space-y-8">
               <div className="space-y-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{title}</p>
-                <h1 className="text-3xl font-semibold tracking-tight text-foreground">{panelTitle}</h1>
+                <h1 className="text-3xl font-semibold text-foreground">{panelTitle}</h1>
                 <p className="text-sm text-muted-foreground">{description}</p>
               </div>
               {children}
@@ -55,7 +55,7 @@ export default function AuthSplitLayout({
 
             <div className="absolute bottom-8 left-8 right-8 space-y-2 text-white">
               <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/70">{panelFootnote}</p>
-              <h2 className="text-2xl font-semibold tracking-tight">{panelTitle}</h2>
+              <h2 className="text-2xl font-semibold">{panelTitle}</h2>
               <p className="max-w-sm text-sm text-white/80">{panelDescription}</p>
             </div>
           </aside>

--- a/ui/src/components/dashboard/ClusterOverview.tsx
+++ b/ui/src/components/dashboard/ClusterOverview.tsx
@@ -88,7 +88,7 @@ export function DashboardClusterOverview({
   return (
     <Card className="h-full">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base font-medium">
+        <CardTitle className="flex items-center gap-2">
           <Server className="h-4 w-4" />
           Cluster Nodes & Health
         </CardTitle>

--- a/ui/src/components/dashboard/MetricsChart.test.ts
+++ b/ui/src/components/dashboard/MetricsChart.test.ts
@@ -15,6 +15,13 @@ describe("buildMetricChartData", () => {
         parquet_files_written_per_second: 2.5,
         parquet_files_read_per_second: 1.75,
         manifest_cache_rocksdb_entries: 9,
+        active_connections_peak: 6,
+        subscription_changes_delivered_per_second: 12,
+        pubsub_active_consumers: 4,
+        pubsub_messages_consumed_per_second: 3,
+        pubsub_messages_consumed_peak_per_second: 9,
+        pubsub_kb_consumed_per_second: 2.5,
+        topic_cache_topic_count: 8,
       },
       {
         sampled_at: 1_000,
@@ -27,6 +34,13 @@ describe("buildMetricChartData", () => {
         parquet_files_written_per_second: 1,
         parquet_files_read_per_second: 0.5,
         manifest_cache_rocksdb_entries: 7,
+        active_connections_peak: 5,
+        subscription_changes_delivered_per_second: 2,
+        pubsub_active_consumers: 1,
+        pubsub_messages_consumed_per_second: 0.5,
+        pubsub_messages_consumed_peak_per_second: 4,
+        pubsub_kb_consumed_per_second: 0.25,
+        topic_cache_topic_count: 3,
       },
     ]);
 
@@ -43,6 +57,13 @@ describe("buildMetricChartData", () => {
     expect(chartData[1].parquet_files_written_per_second).toBe(2.5);
     expect(chartData[1].parquet_files_read_per_second).toBe(1.75);
     expect(chartData[1].manifest_cache_rocksdb_entries).toBe(9);
+    expect(chartData[1].active_connections_peak).toBe(6);
+    expect(chartData[1].subscription_changes_delivered_per_second).toBe(12);
+    expect(chartData[1].pubsub_active_consumers).toBe(4);
+    expect(chartData[1].pubsub_messages_consumed_per_second).toBe(3);
+    expect(chartData[1].pubsub_messages_consumed_peak_per_second).toBe(9);
+    expect(chartData[1].pubsub_kb_consumed_per_second).toBe(2.5);
+    expect(chartData[1].topic_cache_topic_count).toBe(8);
   });
 
   it("skips samples with invalid timestamps", () => {

--- a/ui/src/components/dashboard/MetricsChart.tsx
+++ b/ui/src/components/dashboard/MetricsChart.tsx
@@ -23,6 +23,7 @@ interface TimeSeriesData {
 interface MetricsChartProps {
   data: DashboardMetricSample[];
   isLoading?: boolean;
+  trailingPanel?: ReactNode;
 }
 
 function formatTimeLabel(timestamp: number): string {
@@ -36,6 +37,11 @@ function formatRateValue(value: number | string): string {
   return numeric.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
 
+function formatMetricTooltip(value: number | string, name: string | number | undefined): string {
+  const formatted = formatRateValue(value);
+  return String(name).includes("/s") ? `${formatted}/s` : formatted;
+}
+
 const tooltipStyle = {
   border: "none",
   borderRadius: "8px",
@@ -46,7 +52,7 @@ function ChartCard({ title, children }: { title: string; children: ReactNode }) 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base font-medium">{title}</CardTitle>
+        <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent className="h-80">{children}</CardContent>
     </Card>
@@ -73,12 +79,13 @@ export function buildMetricChartData(data: DashboardMetricSample[]): TimeSeriesD
   });
 }
 
-export function MetricsChart({ data, isLoading }: MetricsChartProps) {
+export function MetricsChart({ data, isLoading, trailingPanel }: MetricsChartProps) {
   const chartData = useMemo(() => buildMetricChartData(data), [data]);
+  const gridClassName = "mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2";
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+      <div className={gridClassName}>
         <Card className="h-96 flex items-center justify-center text-muted-foreground">
           Loading query activity...
         </Card>
@@ -86,27 +93,32 @@ export function MetricsChart({ data, isLoading }: MetricsChartProps) {
           Loading connection metrics...
         </Card>
         <Card className="h-96 flex items-center justify-center text-muted-foreground">
+          Loading pub/sub metrics...
+        </Card>
+        <Card className="h-96 flex items-center justify-center text-muted-foreground">
           Loading resource metrics...
         </Card>
         <Card className="h-96 flex items-center justify-center text-muted-foreground">
           Loading storage metrics...
         </Card>
+        {trailingPanel}
       </div>
     );
   }
 
   if (chartData.length === 0) {
     return (
-      <div className="grid grid-cols-1 gap-4 mt-6">
+      <div className={gridClassName}>
         <Card className="h-64 flex items-center justify-center text-muted-foreground">
           No historical metric data available yet.
         </Card>
+        {trailingPanel}
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+    <div className={gridClassName}>
       <ChartCard title="SQL Query Activity">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
@@ -128,13 +140,33 @@ export function MetricsChart({ data, isLoading }: MetricsChartProps) {
           <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} opacity={0.3} />
             <XAxis dataKey="timestamp" type="number" domain={["dataMin", "dataMax"]} tickFormatter={formatTimeLabel} tick={{ fontSize: 12 }} tickMargin={10} minTickGap={30} />
-            <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
-            <Tooltip labelFormatter={(value) => formatTimeLabel(Number(value))} contentStyle={tooltipStyle} />
+            <YAxis yAxisId="count" tick={{ fontSize: 12 }} allowDecimals={false} />
+            <YAxis yAxisId="rate" orientation="right" tick={{ fontSize: 12 }} tickFormatter={formatRateValue} />
+            <Tooltip formatter={(value, name) => formatMetricTooltip(value as number, name)} labelFormatter={(value) => formatTimeLabel(Number(value))} contentStyle={tooltipStyle} />
             <Legend wrapperStyle={{ paddingTop: "20px" }} />
-            <Line type="monotone" dataKey="active_connections" name="Connections" stroke="#2563eb" strokeWidth={2} dot={false} connectNulls activeDot={{ r: 4 }} />
-            <Line type="monotone" dataKey="active_subscriptions" name="Subscriptions" stroke="#16a34a" strokeWidth={2} dot={false} connectNulls activeDot={{ r: 4 }} />
-            <Line type="step" dataKey="active_subscriptions_peak" name="Peak Subscriptions" stroke="#f59e0b" strokeDasharray="5 5" strokeWidth={2} dot={false} connectNulls />
-            <Line type="step" dataKey="websocket_sessions_peak" name="Peak Sockets" stroke="#dc2626" strokeDasharray="5 5" strokeWidth={2} dot={false} connectNulls />
+            <Line yAxisId="count" type="monotone" dataKey="active_connections" name="Connections" stroke="#2563eb" strokeWidth={2} dot={false} connectNulls activeDot={{ r: 4 }} />
+            <Line yAxisId="count" type="step" dataKey="active_connections_peak" name="Peak Connections" stroke="#dc2626" strokeDasharray="5 5" strokeWidth={2} dot={false} connectNulls />
+            <Line yAxisId="count" type="monotone" dataKey="active_subscriptions" name="Subscriptions" stroke="#16a34a" strokeWidth={2} dot={false} connectNulls activeDot={{ r: 4 }} />
+            <Line yAxisId="count" type="step" dataKey="active_subscriptions_peak" name="Peak Subscriptions" stroke="#f59e0b" strokeDasharray="5 5" strokeWidth={2} dot={false} connectNulls />
+            <Line yAxisId="rate" type="step" dataKey="subscription_changes_delivered_per_second" name="Changes/s" stroke="#0891b2" strokeWidth={2} dot={false} connectNulls />
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      <ChartCard title="Pub/Sub Consumers">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} opacity={0.3} />
+            <XAxis dataKey="timestamp" type="number" domain={["dataMin", "dataMax"]} tickFormatter={formatTimeLabel} tick={{ fontSize: 12 }} tickMargin={10} minTickGap={30} />
+            <YAxis yAxisId="count" tick={{ fontSize: 12 }} allowDecimals={false} />
+            <YAxis yAxisId="rate" orientation="right" tick={{ fontSize: 12 }} tickFormatter={formatRateValue} />
+            <Tooltip formatter={(value, name) => formatMetricTooltip(value as number, name)} labelFormatter={(value) => formatTimeLabel(Number(value))} contentStyle={tooltipStyle} />
+            <Legend wrapperStyle={{ paddingTop: "20px" }} />
+            <Line yAxisId="count" type="monotone" dataKey="pubsub_active_consumers" name="Active Consumers" stroke="#2563eb" strokeWidth={2} dot={false} connectNulls activeDot={{ r: 4 }} />
+            <Line yAxisId="rate" type="step" dataKey="pubsub_messages_consumed_per_second" name="Msg/s" stroke="#16a34a" strokeWidth={2} dot={false} connectNulls />
+            <Line yAxisId="rate" type="step" dataKey="pubsub_messages_consumed_peak_per_second" name="Peak Msg/s" stroke="#f59e0b" strokeDasharray="5 5" strokeWidth={2} dot={false} connectNulls />
+            <Line yAxisId="rate" type="step" dataKey="pubsub_kb_consumed_per_second" name="KB/s" stroke="#7c3aed" strokeWidth={2} dot={false} connectNulls />
+            <Line yAxisId="count" type="monotone" dataKey="topic_cache_topic_count" name="Total Topics" stroke="#dc2626" strokeDasharray="6 4" strokeWidth={2} dot={false} connectNulls />
           </LineChart>
         </ResponsiveContainer>
       </ChartCard>
@@ -157,7 +189,7 @@ export function MetricsChart({ data, isLoading }: MetricsChartProps) {
         </ResponsiveContainer>
       </ChartCard>
 
-      <ChartCard title="Manifest & Parquet Activity">
+      <ChartCard title="Manifest & Parquet Rates">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} opacity={0.3} />
@@ -174,6 +206,8 @@ export function MetricsChart({ data, isLoading }: MetricsChartProps) {
           </LineChart>
         </ResponsiveContainer>
       </ChartCard>
+
+      {trailingPanel}
     </div>
   );
 }

--- a/ui/src/components/dashboard/SlowQueriesPanel.test.tsx
+++ b/ui/src/components/dashboard/SlowQueriesPanel.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SlowQueriesPanel } from "@/components/dashboard/SlowQueriesPanel";
+import type { SlowQuery } from "@/services/systemTableService";
+
+describe("SlowQueriesPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders slow queries with timestamp, SQL, duration, and colored priority", () => {
+    const queries: SlowQuery[] = [
+      {
+        timestamp: "2026-05-28T11:00:00Z",
+        timestamp_ms: 1_779_964_800_000,
+        duration_ms: 250,
+        user_id: "root",
+        table_type: "user",
+        table_name: "events",
+        row_count: 1,
+        query: "SELECT * FROM events LIMIT 100",
+      },
+      {
+        timestamp: "2026-05-28T11:01:00Z",
+        timestamp_ms: 1_779_964_860_000,
+        duration_ms: 1500,
+        user_id: "root",
+        table_type: "user",
+        table_name: "orders",
+        row_count: 1,
+        query: "SELECT * FROM orders WHERE status = 'pending'",
+      },
+      {
+        timestamp: "2026-05-28T11:02:00Z",
+        timestamp_ms: 1_779_964_920_000,
+        duration_ms: 7200,
+        user_id: "root",
+        table_type: "user",
+        table_name: "audit",
+        row_count: 1,
+        query: "SELECT * FROM audit_log ORDER BY timestamp DESC",
+      },
+    ];
+
+    render(<SlowQueriesPanel queries={queries} />);
+
+    expect(screen.getByText("Slow Queries")).toBeTruthy();
+    expect(screen.getByText("Timestamp")).toBeTruthy();
+    expect(screen.getByText("SQL statement")).toBeTruthy();
+    expect(screen.getByText("Time took")).toBeTruthy();
+    expect(screen.getByText("Priority")).toBeTruthy();
+    expect(screen.getByText("SELECT * FROM events LIMIT 100")).toBeTruthy();
+    expect(screen.getByText("SELECT * FROM orders WHERE status = 'pending'")).toBeTruthy();
+    expect(screen.getByText("SELECT * FROM audit_log ORDER BY timestamp DESC")).toBeTruthy();
+    expect(screen.getByText("250 ms")).toBeTruthy();
+    expect(screen.getByText("1500 ms")).toBeTruthy();
+    expect(screen.getByText("7200 ms")).toBeTruthy();
+    expect(screen.getByText("Low")).toBeTruthy();
+    expect(screen.getByText("Medium")).toBeTruthy();
+    expect(screen.getByText("High")).toBeTruthy();
+  });
+
+  it("renders an empty state when no slow queries are available", () => {
+    render(<SlowQueriesPanel queries={[]} />);
+
+    expect(screen.getByText("No slow queries recorded.")).toBeTruthy();
+  });
+});

--- a/ui/src/components/dashboard/SlowQueriesPanel.tsx
+++ b/ui/src/components/dashboard/SlowQueriesPanel.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
@@ -14,9 +15,41 @@ interface SlowQueriesPanelProps {
   isLoading?: boolean;
 }
 
-function formatDuration(value: unknown): string {
+type SlowQueryPriority = "low" | "medium" | "high";
+
+function normalizeDuration(value: unknown): number {
   const duration = typeof value === "number" ? value : Number(value ?? 0);
-  if (!Number.isFinite(duration)) {
+  return Number.isFinite(duration) ? duration : 0;
+}
+
+function getSlowQueryPriority(durationMs: unknown): SlowQueryPriority {
+  const duration = normalizeDuration(durationMs);
+  if (duration >= 5000) {
+    return "high";
+  }
+  if (duration >= 1000) {
+    return "medium";
+  }
+  return "low";
+}
+
+function priorityLabel(priority: SlowQueryPriority): string {
+  return priority.charAt(0).toUpperCase() + priority.slice(1);
+}
+
+function priorityClassName(priority: SlowQueryPriority): string {
+  if (priority === "high") {
+    return "bg-red-100 text-red-800 hover:bg-red-100";
+  }
+  if (priority === "medium") {
+    return "bg-yellow-100 text-yellow-800 hover:bg-yellow-100";
+  }
+  return "bg-green-100 text-green-800 hover:bg-green-100";
+}
+
+function formatDuration(value: unknown): string {
+  const duration = normalizeDuration(value);
+  if (duration <= 0) {
     return "-";
   }
 
@@ -44,9 +77,9 @@ function formatTimestamp(value: unknown): string {
 
 export function SlowQueriesPanel({ queries, isLoading }: SlowQueriesPanelProps) {
   return (
-    <Card className="mt-6">
+    <Card>
       <CardHeader>
-        <CardTitle className="text-base font-medium">Slow Queries</CardTitle>
+        <CardTitle>Slow Queries</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -58,30 +91,35 @@ export function SlowQueriesPanel({ queries, isLoading }: SlowQueriesPanelProps) 
             No slow queries recorded.
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[170px]">Time</TableHead>
-                <TableHead className="w-[110px]">Duration</TableHead>
-                <TableHead className="w-[140px]">User</TableHead>
-                <TableHead className="w-[140px]">Table</TableHead>
-                <TableHead>Query</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {queries.map((query) => (
-                <TableRow key={`${query.timestamp_ms}-${query.query}`}>
-                  <TableCell>{formatTimestamp(query.timestamp)}</TableCell>
-                  <TableCell>{formatDuration(query.duration_ms)}</TableCell>
-                  <TableCell>{query.user_id}</TableCell>
-                  <TableCell>{query.table_name ?? query.table_type}</TableCell>
-                  <TableCell className="max-w-[520px] whitespace-normal break-words font-mono text-[11px] leading-relaxed">
-                    {query.query}
-                  </TableCell>
+          <div className="overflow-x-auto">
+            <Table className="min-w-[760px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[180px]">Timestamp</TableHead>
+                  <TableHead>SQL statement</TableHead>
+                  <TableHead className="w-[120px]">Time took</TableHead>
+                  <TableHead className="w-[120px]">Priority</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {queries.map((query) => {
+                  const priority = getSlowQueryPriority(query.duration_ms);
+                  return (
+                    <TableRow key={`${query.timestamp_ms}-${query.query}`}>
+                      <TableCell>{formatTimestamp(query.timestamp)}</TableCell>
+                      <TableCell className="max-w-[680px] whitespace-normal break-words font-mono text-[11px] leading-relaxed">
+                        {query.query}
+                      </TableCell>
+                      <TableCell>{formatDuration(query.duration_ms)}</TableCell>
+                      <TableCell>
+                        <Badge className={priorityClassName(priority)}>{priorityLabel(priority)}</Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/ui/src/components/dashboard/StorageUsageChart.tsx
+++ b/ui/src/components/dashboard/StorageUsageChart.tsx
@@ -75,7 +75,7 @@ export function StorageUsageChart({
     <Card>
       <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
         <div>
-          <CardTitle className="text-base font-medium">Storage Usage</CardTitle>
+          <CardTitle>Storage Usage</CardTitle>
           <p className="mt-1 text-sm text-muted-foreground">
             Capacity and usage for the selected storage backend.
           </p>

--- a/ui/src/components/jobs/JobList.tsx
+++ b/ui/src/components/jobs/JobList.tsx
@@ -260,15 +260,15 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
               <span>per page</span>
             </div>
             <div className="flex items-center gap-1">
-              <Button variant="outline" size="icon" className="h-8 w-8" disabled={page === 0} onClick={() => handlePageChange(page - 1)}>
+              <Button variant="outline" size="icon-sm" disabled={page === 0} onClick={() => handlePageChange(page - 1)}>
                 <ChevronLeft className="h-4 w-4" />
               </Button>
               <span className="text-sm text-muted-foreground px-2">{page + 1}</span>
-              <Button variant="outline" size="icon" className="h-8 w-8" disabled={jobs.length < pageSize} onClick={() => handlePageChange(page + 1)}>
+              <Button variant="outline" size="icon-sm" disabled={jobs.length < pageSize} onClick={() => handlePageChange(page + 1)}>
                 <ChevronRight className="h-4 w-4" />
               </Button>
             </div>
-            <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => refetch()} disabled={isLoading} aria-label="Refresh jobs">
+            <Button variant="outline" size="icon-sm" onClick={() => refetch()} disabled={isLoading} aria-label="Refresh jobs">
               <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
             </Button>
           </div>

--- a/ui/src/components/layout/PageLayout.tsx
+++ b/ui/src/components/layout/PageLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { PageHeader } from "./typography";
 
 interface PageLayoutProps {
   title: string;
@@ -19,17 +20,9 @@ export function PageLayout({
   contentClassName,
 }: PageLayoutProps) {
   return (
-    <section className={cn("space-y-6 p-4 lg:p-6", className)}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="space-y-1">
-          <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
-          {description ? (
-            <p className="text-sm text-muted-foreground">{description}</p>
-          ) : null}
-        </div>
-        {actions ? <div className="shrink-0">{actions}</div> : null}
-      </div>
-      <div className={cn("space-y-4", contentClassName)}>{children}</div>
+    <section className={cn("flex flex-col gap-6 p-4 lg:p-6", className)}>
+      <PageHeader title={title} description={description} actions={actions} />
+      <div className={cn("flex flex-col gap-4", contentClassName)}>{children}</div>
     </section>
   );
 }

--- a/ui/src/components/layout/typography.tsx
+++ b/ui/src/components/layout/typography.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export const pageTitleClassName = "text-2xl font-semibold text-foreground";
+export const pageDescriptionClassName = "text-sm text-muted-foreground";
+export const panelTitleClassName = "text-sm font-semibold text-foreground";
+export const panelDescriptionClassName = "text-xs/relaxed text-muted-foreground";
+export const sectionTitleClassName = "text-sm font-semibold text-foreground";
+export const chromeLabelClassName = "text-[10px] font-medium uppercase text-muted-foreground";
+export const fieldLabelClassName = "text-xs font-medium text-muted-foreground";
+
+interface PageHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn("flex flex-wrap items-start justify-between gap-3", className)}>
+      <div className="flex min-w-0 flex-col gap-1">
+        <h1 className={pageTitleClassName}>{title}</h1>
+        {description ? <p className={pageDescriptionClassName}>{description}</p> : null}
+      </div>
+      {actions ? <div className="shrink-0">{actions}</div> : null}
+    </div>
+  );
+}
+
+interface PanelHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+  titleId?: string;
+  headingLevel?: "h2" | "h3";
+}
+
+export function PanelHeader({
+  title,
+  description,
+  actions,
+  className,
+  titleId,
+  headingLevel = "h2",
+}: PanelHeaderProps) {
+  const TitleTag = headingLevel;
+
+  return (
+    <div className={cn("flex min-w-0 items-start justify-between gap-3", className)}>
+      <div className="min-w-0">
+        <TitleTag id={titleId} className={panelTitleClassName}>
+          {title}
+        </TitleTag>
+        {description ? <p className={panelDescriptionClassName}>{description}</p> : null}
+      </div>
+      {actions ? <div className="shrink-0">{actions}</div> : null}
+    </div>
+  );
+}

--- a/ui/src/components/sql-studio-v2/browser-tree/StudioExplorerPanel.tsx
+++ b/ui/src/components/sql-studio-v2/browser-tree/StudioExplorerPanel.tsx
@@ -13,7 +13,6 @@ import {
   User,
   Users,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -23,6 +22,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { StudioChromeLabel, StudioIconButton } from "../shared/StudioChrome";
 import type { SavedQuery, StudioNamespace, StudioTable } from "../shared/types";
 
 interface StudioExplorerPanelProps {
@@ -100,8 +100,8 @@ const StudioExplorerPanelComponent = ({
   onTableContextMenu,
 }: StudioExplorerPanelProps) => {
   const normalizedFilter = filter.trim().toLowerCase();
-  const sectionButtonClassName = "flex w-full items-center gap-1.5 px-1 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground hover:bg-accent rounded-sm";
-  const sectionBadgeClassName = "ml-auto inline-flex items-center justify-center rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium tracking-normal text-foreground";
+  const sectionButtonClassName = "flex w-full items-center gap-1.5 rounded-sm px-1 py-1.5 text-left text-xs font-semibold uppercase text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
+  const sectionBadgeClassName = "ml-auto inline-flex items-center justify-center rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium text-foreground";
 
   const filteredSchema = useMemo(() => {
     return schema
@@ -136,19 +136,15 @@ const StudioExplorerPanelComponent = ({
       <div className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border bg-background text-foreground">
         <div className="shrink-0 border-b border-border pl-3 pr-2 py-2">
           <div className="flex items-center justify-between gap-1 mb-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Explorer</p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+            <StudioChromeLabel>Explorer</StudioChromeLabel>
+            <StudioIconButton
               onClick={onRefresh}
               disabled={isRefreshing}
               aria-label="Refresh explorer"
-              title="Refresh explorer"
+              tooltip="Refresh explorer"
             >
-              <RefreshCw className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")} />
-            </Button>
+              <RefreshCw className={cn(isRefreshing && "animate-spin")} data-icon="only" />
+            </StudioIconButton>
           </div>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/ui/src/components/sql-studio-v2/input-form/StudioEditorPanel.tsx
+++ b/ui/src/components/sql-studio-v2/input-form/StudioEditorPanel.tsx
@@ -12,6 +12,8 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { panelDescriptionClassName, panelTitleClassName } from "@/components/layout/typography";
+import { StudioChromeLabel, StudioIconButton } from "../shared/StudioChrome";
 import type { LiveSubscriptionOptions, StudioNamespace } from "../shared/types";
 import {
   buildSqlCompletionData,
@@ -330,24 +332,21 @@ export function StudioEditorPanel({
                 }
               }}
               autoFocus
-              className="h-7 w-full max-w-[320px] rounded border border-border bg-background px-2 text-base font-semibold text-foreground outline-none ring-2 ring-ring"
+              className={`h-7 w-full max-w-[320px] rounded border border-border bg-background px-2 outline-none ring-2 ring-ring ${panelTitleClassName}`}
             />
           ) : (
             <div className="flex items-center gap-1.5">
-              <p className="truncate text-base font-semibold text-foreground">{tabTitle}</p>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+              <p className={`truncate ${panelTitleClassName}`}>{tabTitle}</p>
+              <StudioIconButton
                 onClick={() => setIsEditingTitle(true)}
-                title="Rename query"
+                tooltip="Rename query"
+                aria-label="Rename query"
               >
-                <PenLine className="h-3.5 w-3.5" />
-              </Button>
+                <PenLine data-icon="only" />
+              </StudioIconButton>
             </div>
           )}
-          <p className="text-xs text-muted-foreground">Draft</p>
+          <p className={panelDescriptionClassName}>Draft</p>
         </div>
         <div className="flex items-center gap-2">
           <div className="hidden items-center gap-2 lg:flex">
@@ -361,15 +360,13 @@ export function StudioEditorPanel({
                 Live query
               </span>
               {isLive && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                <StudioIconButton
                   onClick={() => setShowSubscriptionOptions((prev) => !prev)}
-                  title="Subscription options"
+                  tooltip="Subscription options"
+                  aria-label="Subscription options"
                 >
-                  <Settings2 className="h-3.5 w-3.5" />
-                </Button>
+                  <Settings2 data-icon="only" />
+                </StudioIconButton>
               )}
             </div>
             <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -383,7 +380,7 @@ export function StudioEditorPanel({
             className="shrink-0"
             onClick={onSave}
           >
-            <Save className="mr-1.5 h-3.5 w-3.5" />
+            <Save data-icon="inline-start" />
             Save
           </Button>
           {isLive ? (
@@ -394,9 +391,9 @@ export function StudioEditorPanel({
               disabled={isExecuteDisabled}
             >
               {liveStatus === "connected" || isConnectingLive ? (
-                <Square className="mr-1.5 h-3.5 w-3.5" />
+                <Square data-icon="inline-start" />
               ) : (
-                <Play className="mr-1.5 h-3.5 w-3.5" />
+                <Play data-icon="inline-start" />
               )}
               {liveStatus === "connected"
                 ? "Stop"
@@ -412,7 +409,7 @@ export function StudioEditorPanel({
                 onClick={() => runSql("auto")}
                 disabled={isExecuteDisabled}
               >
-                <Play className="mr-1.5 h-3.5 w-3.5" />
+                <Play data-icon="inline-start" />
                 {isRunning ? "Running..." : executeLabel}
               </Button>
               <DropdownMenu>
@@ -449,11 +446,10 @@ export function StudioEditorPanel({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="secondary"
-                size="icon"
-                className="h-8 w-8"
+                size="icon-sm"
                 aria-label="More query actions"
               >
-                <MoreHorizontal className="h-4 w-4" />
+                <MoreHorizontal data-icon="only" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -476,7 +472,7 @@ export function StudioEditorPanel({
 
       {isLive && showSubscriptionOptions && (
         <div className="flex shrink-0 items-center gap-4 border-b border-border bg-muted/30 px-4 py-2">
-          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Options</span>
+          <StudioChromeLabel>Options</StudioChromeLabel>
           <div className="flex items-center gap-1.5">
             <label className="text-xs text-muted-foreground" htmlFor="opt-last-rows">last_rows</label>
             <Input

--- a/ui/src/components/sql-studio-v2/inspector/StudioInspectorPanel.tsx
+++ b/ui/src/components/sql-studio-v2/inspector/StudioInspectorPanel.tsx
@@ -2,6 +2,7 @@ import { Clock3, History, Info } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { chromeLabelClassName } from "@/components/layout/typography";
 import { formatDate } from "@/lib/formatters";
 import type {
   QueryRunSummary,
@@ -218,7 +219,7 @@ function MetadataList({ items }: { items: InspectorItem[] }) {
           key={item.label}
           className={`flex items-start justify-between gap-3 px-3 py-2 ${index === 0 ? "" : "border-t border-border"}`}
         >
-          <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          <span className={chromeLabelClassName}>
             {item.label}
           </span>
           <span className="max-w-[65%] text-right text-sm text-foreground whitespace-pre-wrap break-words">
@@ -266,7 +267,7 @@ export function StudioInspectorPanel({
                 <div className="space-y-2">
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Table Information</p>
+                      <p className={chromeLabelClassName}>Table Information</p>
                       <p className="text-sm font-semibold text-foreground">
                         {selectedTable.namespace}.{selectedTable.name}
                       </p>
@@ -284,7 +285,7 @@ export function StudioInspectorPanel({
                 </div>
 
                 <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Table Schema</p>
+                  <p className={chromeLabelClassName}>Table Schema</p>
                   {selectedTable.columns.map((column) => (
                     <div key={column.name} className="rounded-md border border-border bg-background p-2">
                       <div className="flex items-center justify-between gap-2">
@@ -300,7 +301,7 @@ export function StudioInspectorPanel({
                 </div>
 
                 <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Table Options</p>
+                  <p className={chromeLabelClassName}>Table Options</p>
                   {tableOptionItems.length > 0 ? (
                     <MetadataList items={tableOptionItems} />
                   ) : (

--- a/ui/src/components/sql-studio-v2/preview/StudioResultsGrid.tsx
+++ b/ui/src/components/sql-studio-v2/preview/StudioResultsGrid.tsx
@@ -38,6 +38,7 @@ import { classifyFieldKind, coerceFieldValue } from "@/components/sql-studio-v2/
 import { LIVE_META, LIVE_HIGHLIGHT_DURATION_MS } from "@/features/sql-studio/state/sqlStudioWorkspaceSlice";
 import { cn } from "@/lib/utils";
 import { StudioExecutionLog } from "./logs/StudioExecutionLog";
+import { chromeLabelClassName } from "@/components/layout/typography";
 import type { QueryResultData, SqlStudioResultView, StudioTable } from "../shared/types";
 
 interface StudioResultsGridProps {
@@ -746,7 +747,7 @@ export function StudioResultsGrid({
                 <tr>
                   {isLiveMode ? (
                     <th className="w-[148px] border-r border-border bg-muted/40 px-2 py-2 text-left">
-                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      <span className={chromeLabelClassName}>
                         Live
                       </span>
                     </th>
@@ -789,11 +790,11 @@ export function StudioResultsGrid({
                           onClick={() => handleSortColumn(field.name)}
                         >
                           <span>
-                            <span className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide">
+                            <span className={cn("flex items-center gap-1.5", chromeLabelClassName, "text-foreground")}>
                               <span>{field.name}</span>
                               {field.isPrimaryKey && (
                                 <span
-                                  className="inline-flex items-center gap-1 rounded bg-amber-400/20 px-1 py-0.5 text-[9px] font-semibold tracking-normal text-amber-300"
+                                  className="inline-flex items-center gap-1 rounded bg-amber-400/20 px-1 py-0.5 text-[9px] font-semibold text-amber-300"
                                   title="Primary key column"
                                 >
                                   <KeyRound className="h-2.5 w-2.5" />
@@ -878,7 +879,7 @@ export function StudioResultsGrid({
                             {liveChangeLabel && (
                               <span
                                 className={cn(
-                                  "inline-flex w-fit items-center rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide",
+                                  "inline-flex w-fit items-center rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase",
                                   liveChangeType === "initial" && "bg-sky-500/12 text-sky-700",
                                   liveChangeType === "insert" && "bg-sky-500/20 text-sky-700",
                                   liveChangeType === "update" && "bg-amber-500/20 text-amber-700",

--- a/ui/src/components/sql-studio-v2/preview/logs/StudioExecutionLog.tsx
+++ b/ui/src/components/sql-studio-v2/preview/logs/StudioExecutionLog.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, ArrowDown, ArrowUp, CheckCircle2, Info } from "lucide-reac
 import { Badge } from "@/components/ui/badge";
 import { CodeBlock } from "@/components/ui/code-block";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { PanelHeader, chromeLabelClassName } from "@/components/layout/typography";
 import { cn } from "@/lib/utils";
 import type { QueryLogEntry } from "../../shared/types";
 
@@ -273,27 +274,28 @@ export function StudioExecutionLog({ logs, status }: StudioExecutionLogProps) {
     <div className="flex min-h-0 min-w-0 flex-1 flex-col xl:flex-row">
       <section aria-label="Trace timeline" className="flex min-h-[220px] min-w-0 flex-col border-b border-border bg-muted/10 xl:w-[40%] xl:min-w-[300px] xl:max-w-[500px] xl:border-b-0 xl:border-r">
           <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                Timeline Stream
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {websocketFrameCount > 0
-                  ? `${websocketFrameCount} frame${websocketFrameCount === 1 ? "" : "s"} captured • ${logs.length} total event${logs.length === 1 ? "" : "s"}`
-                  : `${logs.length} event${logs.length === 1 ? "" : "s"}`}
-              </p>
-            </div>
-            <Badge
-              variant="outline"
-              className={cn(
-                "text-[10px] font-semibold uppercase tracking-wide",
+            <PanelHeader
+              title="Timeline Stream"
+              className="flex-1"
+              description={
                 websocketFrameCount > 0
-                  ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700"
-                  : "border-border bg-muted/40 text-muted-foreground",
-              )}
-            >
-              {websocketFrameCount > 0 ? "WS Trace" : "Execution"}
-            </Badge>
+                  ? `${websocketFrameCount} frame${websocketFrameCount === 1 ? "" : "s"} captured • ${logs.length} total event${logs.length === 1 ? "" : "s"}`
+                  : `${logs.length} event${logs.length === 1 ? "" : "s"}`
+              }
+              actions={
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "text-[10px] font-semibold uppercase",
+                    websocketFrameCount > 0
+                      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700"
+                      : "border-border bg-muted/40 text-muted-foreground",
+                  )}
+                >
+                  {websocketFrameCount > 0 ? "WS Trace" : "Execution"}
+                </Badge>
+              }
+            />
           </div>
           <ScrollArea className="min-h-0 flex-1 [&>[data-radix-scroll-area-viewport]>div]:!block">
             <div className="space-y-1.5 p-2">
@@ -316,7 +318,7 @@ export function StudioExecutionLog({ logs, status }: StudioExecutionLogProps) {
                   >
                     <div className="flex items-center gap-2">
                       <item.Icon className={cn("h-3.5 w-3.5 shrink-0", getIconClassName(item.kind, status))} />
-                      <Badge variant="outline" className={cn("px-1.5 py-0 text-[10px] font-semibold uppercase tracking-wide", getBadgeClassName(item.kind))}>
+                      <Badge variant="outline" className={cn("px-1.5 py-0 text-[10px] font-semibold uppercase", getBadgeClassName(item.kind))}>
                         {item.label}
                       </Badge>
                       <p
@@ -354,7 +356,7 @@ export function StudioExecutionLog({ logs, status }: StudioExecutionLogProps) {
       <section aria-label="Trace details" className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
           <div className="min-w-0 border-b border-border px-4 py-3">
             <div className="flex min-w-0 items-center gap-2">
-              <Badge variant="outline" className={cn("shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide", getBadgeClassName(selectedEntry.kind))}>
+              <Badge variant="outline" className={cn("shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase", getBadgeClassName(selectedEntry.kind))}>
                 {selectedEntry.label}
               </Badge>
               <h3 className="min-w-0 flex-1 truncate font-mono text-sm text-foreground">
@@ -372,7 +374,7 @@ export function StudioExecutionLog({ logs, status }: StudioExecutionLogProps) {
             </div>
           </div>
 
-          <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+          <div className={`flex shrink-0 items-center gap-2 border-b border-border px-4 py-2 ${chromeLabelClassName}`}>
             <span className="rounded border border-border bg-muted/40 px-2 py-0.5 text-[10px] font-semibold text-foreground">
               Preview
             </span>

--- a/ui/src/components/sql-studio-v2/preview/table/InsertRowDialog.tsx
+++ b/ui/src/components/sql-studio-v2/preview/table/InsertRowDialog.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { chromeLabelClassName } from "@/components/layout/typography";
+import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
@@ -109,10 +111,10 @@ export function InsertRowDialog({ open, table, onSubmit, onClose }: InsertRowDia
                   <span className="font-medium text-foreground">{col.name}</span>
                   <span className="font-mono text-[10px] text-muted-foreground">{col.dataType}</span>
                   {col.isPrimaryKey && (
-                    <span className="text-[10px] uppercase tracking-wide text-yellow-600 dark:text-yellow-500">PK</span>
+                    <span className={cn(chromeLabelClassName, "text-yellow-600 dark:text-yellow-500")}>PK</span>
                   )}
                   {!col.isNullable && (
-                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground">required</span>
+                    <span className={chromeLabelClassName}>required</span>
                   )}
                 </span>
 

--- a/ui/src/components/sql-studio-v2/shared/StudioChrome.tsx
+++ b/ui/src/components/sql-studio-v2/shared/StudioChrome.tsx
@@ -1,0 +1,60 @@
+import type { ComponentProps, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { chromeLabelClassName } from "@/components/layout/typography";
+import { cn } from "@/lib/utils";
+
+export function StudioChromeLabel({ className, ...props }: ComponentProps<"span">) {
+  return <span className={cn(chromeLabelClassName, className)} {...props} />;
+}
+
+type StudioIconButtonProps = Omit<ComponentProps<typeof Button>, "size" | "variant"> & {
+  tooltip?: ReactNode;
+  tone?: "neutral" | "destructive";
+};
+
+export function StudioIconButton({
+  tooltip,
+  tone = "neutral",
+  className,
+  children,
+  disabled,
+  ...props
+}: StudioIconButtonProps) {
+  const button = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xxs"
+      disabled={disabled}
+      className={cn(
+        "text-muted-foreground hover:text-foreground",
+        tone === "destructive" && "hover:bg-destructive/10 hover:text-destructive",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {disabled ? <span className="inline-flex">{button}</span> : button}
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/ui/src/components/sql-studio-v2/studio-tabs/StudioTabsHeader.tsx
+++ b/ui/src/components/sql-studio-v2/studio-tabs/StudioTabsHeader.tsx
@@ -11,6 +11,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { chromeLabelClassName } from "@/components/layout/typography";
 import { cn } from "@/lib/utils";
 
 interface TabConfig {
@@ -44,7 +45,8 @@ export function StudioTabsHeader() {
                   disabled={tab.disabled}
                   onClick={() => dispatch(setActiveStudioTab(tab.value))}
                   className={cn(
-                    "relative flex flex-1 flex-col items-center gap-0.5 rounded-md px-2 py-1.5 text-[10px] font-medium uppercase tracking-wide transition-colors",
+                    "relative flex flex-1 flex-col items-center gap-0.5 rounded-md px-2 py-1.5 transition-colors",
+                    chromeLabelClassName,
                     "hover:bg-accent hover:text-accent-foreground",
                     isActive
                       ? "bg-accent text-accent-foreground"

--- a/ui/src/components/sql-studio-v2/table-editor/EditTableForm.tsx
+++ b/ui/src/components/sql-studio-v2/table-editor/EditTableForm.tsx
@@ -53,11 +53,12 @@ import {
 import { executeSqlPreviewStatement } from "./run-sql";
 import { useSqlPreview } from "@/components/sql-preview";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  PanelHeader,
+  chromeLabelClassName,
+  fieldLabelClassName,
+  sectionTitleClassName,
+} from "@/components/layout/typography";
+import { StudioIconButton } from "../shared/StudioChrome";
 import equal from "fast-deep-equal";
 import { executeSqlStudioQuery } from "@/services/sqlStudioService";
 
@@ -72,7 +73,7 @@ function MetaRow({
 }) {
   return (
     <div className="flex items-baseline gap-2 overflow-hidden">
-      <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+      <span className={`shrink-0 ${chromeLabelClassName}`}>
         {label}
       </span>
       <span
@@ -106,7 +107,7 @@ function SelectField({
 }) {
   return (
     <label className="flex flex-col gap-1.5">
-      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <span className={fieldLabelClassName}>{label}</span>
       <Select value={value} onValueChange={onChange} disabled={disabled}>
         <SelectTrigger size="sm" className="h-8 text-xs" data-testid={testId}>
           <SelectValue />
@@ -144,11 +145,11 @@ function TableOptionsEditor({
 
   return (
     <section className="space-y-3">
-      <h3 className="text-sm font-medium">Options</h3>
+      <h3 className={sectionTitleClassName}>Options</h3>
       <div className="grid grid-cols-1 gap-3 rounded-md border border-border bg-muted/10 p-3 sm:grid-cols-2 lg:grid-cols-3">
         {(draft.tableType === "user" || draft.tableType === "shared") && (
           <label className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-muted-foreground">
+            <span className={fieldLabelClassName}>
               Storage ID
             </span>
             <Input
@@ -163,7 +164,7 @@ function TableOptionsEditor({
 
         {draft.tableType === "user" && (
           <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2">
-            <span className="text-xs font-medium text-muted-foreground">
+            <span className={fieldLabelClassName}>
               Use user storage
             </span>
             <Switch
@@ -208,7 +209,7 @@ function TableOptionsEditor({
         {(draft.tableType === "user" || draft.tableType === "shared") &&
           showFlushRows && (
             <label className="flex flex-col gap-1.5">
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className={fieldLabelClassName}>
                 Flush rows
               </span>
               <Input
@@ -227,7 +228,7 @@ function TableOptionsEditor({
         {(draft.tableType === "user" || draft.tableType === "shared") &&
           showFlushInterval && (
             <label className="flex flex-col gap-1.5">
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className={fieldLabelClassName}>
                 Flush interval
               </span>
               <Input
@@ -248,7 +249,7 @@ function TableOptionsEditor({
         {draft.tableType === "stream" && (
           <>
             <label className="flex flex-col gap-1.5">
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className={fieldLabelClassName}>
                 TTL seconds
               </span>
               <Input
@@ -275,7 +276,7 @@ function TableOptionsEditor({
               testId="table-option-eviction-strategy"
             />
             <label className="flex flex-col gap-1.5">
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className={fieldLabelClassName}>
                 Max stream size
               </span>
               <Input
@@ -291,16 +292,18 @@ function TableOptionsEditor({
           </>
         )}
 
-        <SelectField
-          label="Compression"
-          value={options.compression}
-          options={COMPRESSION_OPTIONS}
-          disabled={disabled}
-          onChange={(value) =>
-            update({ compression: value as DraftTableOptions["compression"] })
-          }
-          testId="table-option-compression"
-        />
+        {draft.tableType !== "stream" && (
+          <SelectField
+            label="Compression"
+            value={options.compression}
+            options={COMPRESSION_OPTIONS}
+            disabled={disabled}
+            onChange={(value) =>
+              update({ compression: value as DraftTableOptions["compression"] })
+            }
+            testId="table-option-compression"
+          />
+        )}
       </div>
     </section>
   );
@@ -425,7 +428,7 @@ export function EditTableForm({
         <div className="rounded-full bg-muted p-4">
           <Pencil className="h-6 w-6 text-muted-foreground" />
         </div>
-        <p className="text-base font-medium">No table selected</p>
+        <p className={sectionTitleClassName}>No table selected</p>
         <p className="max-w-md text-sm text-muted-foreground">
           Pick a table from the sidebar to edit its schema, or use the{" "}
           <span className="font-medium">+</span> next to{" "}
@@ -559,38 +562,24 @@ export function EditTableForm({
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <div className="flex shrink-0 items-center justify-between border-b border-border bg-background px-4 py-3">
-        <div>
-          <h2 className="text-sm font-semibold">
-            {isReadOnly
-              ? "View Table"
-              : isCreating
-                ? "New Table"
-                : "Edit Table"}
-          </h2>
-          <p className="text-xs text-muted-foreground">
-            {isCreating
+        <PanelHeader
+          title={isReadOnly ? "View Table" : isCreating ? "New Table" : "Edit Table"}
+          description={
+            isCreating
               ? `Define a new table under ${draft.namespace}.`
-              : `${isReadOnly ? "Viewing" : "Editing"} ${draft.namespace}.${draft.name}`}
-          </p>
-        </div>
-        <TooltipProvider delayDuration={250}>
-          <div className="flex items-center gap-2">
+              : `${isReadOnly ? "Viewing" : "Editing"} ${draft.namespace}.${draft.name}`
+          }
+        />
+        <div className="flex items-center gap-2">
             {isEditing && !isReadOnly && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                    onClick={handleDropTable}
-                    aria-label="Drop table"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Drop table</TooltipContent>
-              </Tooltip>
+              <StudioIconButton
+                onClick={handleDropTable}
+                tone="destructive"
+                tooltip="Drop table"
+                aria-label="Drop table"
+              >
+                <Trash2 data-icon="only" />
+              </StudioIconButton>
             )}
             {!isReadOnly && (
               <>
@@ -622,7 +611,6 @@ export function EditTableForm({
               </>
             )}
           </div>
-        </TooltipProvider>
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
@@ -647,7 +635,7 @@ export function EditTableForm({
 
           <section className="space-y-4">
             <div className="flex items-baseline gap-2">
-              <h3 className="text-sm font-medium">Namespace</h3>
+              <h3 className={sectionTitleClassName}>Namespace</h3>
               <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
                 {draft.namespace}
               </code>
@@ -666,7 +654,7 @@ export function EditTableForm({
               testId="table-type-select"
             />
             <label className="flex flex-col gap-1.5">
-              <h3 className="text-sm font-medium">Table name</h3>
+              <h3 className={sectionTitleClassName}>Table name</h3>
               <Input
                 value={draft.name}
                 onChange={(e) =>
@@ -692,7 +680,7 @@ export function EditTableForm({
 
           <section className="space-y-2">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-medium">Columns</h3>
+              <h3 className={sectionTitleClassName}>Columns</h3>
               {!isReadOnly && (
                 <Button
                   type="button"
@@ -701,7 +689,7 @@ export function EditTableForm({
                   onClick={addColumn}
                   className="gap-1.5 text-xs"
                 >
-                  <Plus className="h-3.5 w-3.5" />
+                  <Plus data-icon="inline-start" />
                   Add column
                 </Button>
               )}
@@ -709,7 +697,7 @@ export function EditTableForm({
             <div className="overflow-hidden rounded-md border border-border">
               <table className="w-full text-xs">
                 <thead className="bg-muted/40">
-                  <tr className="border-b border-border text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <tr className={`border-b border-border ${chromeLabelClassName}`}>
                     <th className="w-8 px-2 py-2 text-center">PK</th>
                     <th className="px-2 py-2 text-left">Name</th>
                     <th className="w-32 px-2 py-2 text-left">Type</th>
@@ -749,7 +737,7 @@ export function EditTableForm({
                             onClick={addColumn}
                             className="gap-1.5"
                           >
-                            <Plus className="h-3.5 w-3.5" />
+                            <Plus data-icon="inline-start" />
                             Add your first column
                           </Button>
                         </div>
@@ -780,7 +768,7 @@ export function EditTableForm({
 
           {isEditing && selectedTable && (
             <section className="space-y-2">
-              <h3 className="text-sm font-medium">Metadata</h3>
+              <h3 className={sectionTitleClassName}>Metadata</h3>
               <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-muted/20 px-4 py-3 text-xs">
                 <MetaRow label="Type" value={selectedTable.tableType ?? "—"} />
                 <MetaRow

--- a/ui/src/components/sql-studio-v2/table-editor/EditorSidebar.tsx
+++ b/ui/src/components/sql-studio-v2/table-editor/EditorSidebar.tsx
@@ -11,12 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/components/ui/toaster-provider";
 import {
@@ -35,6 +30,7 @@ import equal from "fast-deep-equal";
 import { generateDropTableSql } from "./ddl-generator";
 import { discardEdit } from "@/features/sql-studio/state/editorTabSlice";
 import { useSqlPreview } from "@/components/sql-preview";
+import { StudioChromeLabel, StudioIconButton } from "../shared/StudioChrome";
 import type { StudioNamespace, StudioTable } from "@/components/sql-studio-v2/shared/types";
 
 interface EditorSidebarProps {
@@ -185,22 +181,15 @@ export function EditorSidebar({ schema, defaultNamespace = "default", onSchemaRe
     <div className="flex h-full min-h-0 flex-col">
       <div className="shrink-0 space-y-2 border-b border-border px-2 py-2">
         <div className="flex items-center justify-between">
-          <label className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Namespace
-          </label>
+          <StudioChromeLabel>Namespace</StudioChromeLabel>
           <div className="flex items-center gap-0.5">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => setShowCreateNamespace(true)}
-                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                >
-                  <FolderPlus className="h-3 w-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>Create namespace</TooltipContent>
-            </Tooltip>
+            <StudioIconButton
+              onClick={() => setShowCreateNamespace(true)}
+              tooltip="Create namespace"
+              aria-label="Create namespace"
+            >
+              <FolderPlus data-icon="only" />
+            </StudioIconButton>
             {(() => {
               const isSystem = activeNamespace.startsWith("system") || activeNamespace.startsWith("dba");
               const noNamespaces = namespaces.length === 0;
@@ -211,25 +200,16 @@ export function EditorSidebar({ schema, defaultNamespace = "default", onSchemaRe
                   ? "System namespace — cannot drop"
                   : `Drop namespace "${activeNamespace}"`;
               return (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="block">
-                      <button
-                        type="button"
-                        onClick={handleDropNamespaceClick}
-                        disabled={disabled}
-                        className={cn(
-                          "rounded p-0.5 text-muted-foreground transition-colors",
-                          !disabled && "hover:bg-destructive/10 hover:text-destructive",
-                          disabled && "cursor-not-allowed opacity-30",
-                        )}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </button>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>{tooltipLabel}</TooltipContent>
-                </Tooltip>
+                <StudioIconButton
+                  onClick={handleDropNamespaceClick}
+                  disabled={disabled}
+                  tone="destructive"
+                  tooltip={tooltipLabel}
+                  aria-label="Drop namespace"
+                  className={cn(disabled && "cursor-not-allowed opacity-30")}
+                >
+                  <Trash2 data-icon="only" />
+                </StudioIconButton>
               );
             })()}
           </div>
@@ -270,23 +250,15 @@ export function EditorSidebar({ schema, defaultNamespace = "default", onSchemaRe
 
       {namespaces.length > 0 && (
         <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-1.5">
-          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            Tables ({tablesInNamespace.length})
-          </span>
+          <StudioChromeLabel>Tables ({tablesInNamespace.length})</StudioChromeLabel>
           {!activeNamespaceIsReadOnly && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleCreate}
-                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                  aria-label="New table"
-                >
-                  <Plus className="h-3 w-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>New table</TooltipContent>
-            </Tooltip>
+            <StudioIconButton
+              onClick={handleCreate}
+              tooltip="New table"
+              aria-label="New table"
+            >
+              <Plus data-icon="only" />
+            </StudioIconButton>
           )}
         </div>
       )}
@@ -332,25 +304,19 @@ export function EditorSidebar({ schema, defaultNamespace = "default", onSchemaRe
                   <span className="truncate">{table.name}</span>
                 </button>
                 {!activeNamespaceIsReadOnly && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDropTable(table);
-                        }}
-                        className={cn(
-                          "absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground/60 transition-colors",
-                          "hover:bg-destructive/10 hover:text-destructive",
-                        )}
-                        aria-label={`Drop table ${table.name}`}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>Drop table</TooltipContent>
-                  </Tooltip>
+                  <div className="absolute right-1.5 top-1/2 -translate-y-1/2">
+                    <StudioIconButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDropTable(table);
+                      }}
+                      tone="destructive"
+                      tooltip="Drop table"
+                      aria-label={`Drop table ${table.name}`}
+                    >
+                      <Trash2 data-icon="only" />
+                    </StudioIconButton>
+                  </div>
                 )}
               </li>
             );

--- a/ui/src/components/sql-studio-v2/table-editor/ddl-generator.test.ts
+++ b/ui/src/components/sql-studio-v2/table-editor/ddl-generator.test.ts
@@ -9,7 +9,7 @@ describe("table editor DDL generator", () => {
     draft.options.ttlSeconds = "7200";
     draft.options.evictionStrategy = "hybrid";
     draft.options.maxStreamSizeBytes = "1048576";
-    draft.options.compression = "lz4";
+    draft.options.compression = "zstd";
 
     const sql = generateCreateTableSql(draft);
 
@@ -17,7 +17,7 @@ describe("table editor DDL generator", () => {
     expect(sql).toContain("TTL_SECONDS = 7200");
     expect(sql).toContain("EVICTION_STRATEGY = 'hybrid'");
     expect(sql).toContain("MAX_STREAM_SIZE_BYTES = 1048576");
-    expect(sql).toContain("COMPRESSION = 'lz4'");
+    expect(sql).not.toContain("COMPRESSION");
   });
 
   it("alters only changed shared table options", () => {
@@ -54,14 +54,14 @@ describe("table editor DDL generator", () => {
     draft.options.flushPolicyKind = "combined";
     draft.options.flushRows = "2000";
     draft.options.flushIntervalSeconds = "120";
-    draft.options.compression = "zstd";
+    draft.options.compression = "none";
 
     const sql = generateAlterTableSql(original, draft);
 
     expect(sql).toContain("ALTER TABLE default.settings SET TBLPROPERTIES");
     expect(sql).toContain("ACCESS_LEVEL = 'PUBLIC'");
     expect(sql).toContain("FLUSH_POLICY = 'rows:2000,interval:120'");
-    expect(sql).toContain("COMPRESSION = 'zstd'");
+    expect(sql).toContain("COMPRESSION = 'none'");
     expect(sql).not.toContain("STORAGE_ID");
   });
 });

--- a/ui/src/components/sql-studio-v2/table-editor/ddl-generator.ts
+++ b/ui/src/components/sql-studio-v2/table-editor/ddl-generator.ts
@@ -74,7 +74,6 @@ function tablePropertyMap(
     props.set("TTL_SECONDS", options.ttlSeconds.trim());
     props.set("EVICTION_STRATEGY", quoteLiteral(options.evictionStrategy));
     props.set("MAX_STREAM_SIZE_BYTES", options.maxStreamSizeBytes.trim());
-    props.set("COMPRESSION", quoteLiteral(options.compression));
   }
 
   return props;

--- a/ui/src/components/sql-studio-v2/table-editor/types.ts
+++ b/ui/src/components/sql-studio-v2/table-editor/types.ts
@@ -71,7 +71,7 @@ export type EditorMode = "idle" | "create" | "edit";
 export const TABLE_TYPES = ["user", "shared", "stream"] as const;
 export type DraftTableType = (typeof TABLE_TYPES)[number];
 
-export const COMPRESSION_OPTIONS = ["snappy", "none", "lz4", "zstd"] as const;
+export const COMPRESSION_OPTIONS = ["none", "snappy", "zstd"] as const;
 export type DraftCompression = (typeof COMPRESSION_OPTIONS)[number];
 
 export const ACCESS_LEVEL_OPTIONS = [

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg[data-icon='inline-end']]:ml-1.5 [&_svg[data-icon='inline-start']]:mr-1.5 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -22,10 +22,11 @@ const buttonVariants = cva(
         xs: "h-7 px-2.5 text-xs",
         sm: "h-9 rounded-md px-3",
         lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
-        "icon-xs": "h-7 w-7 rounded-md",
-        "icon-sm": "h-8 w-8 rounded-md",
-        "icon-lg": "h-10 w-10 rounded-md",
+        icon: "size-9",
+        "icon-xxs": "size-6 rounded-md",
+        "icon-xs": "size-7 rounded-md",
+        "icon-sm": "size-8 rounded-md",
+        "icon-lg": "size-10 rounded-md",
       },
     },
     defaultVariants: {

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { panelDescriptionClassName, panelTitleClassName } from "@/components/layout/typography"
 
 function Card({
   className,
@@ -37,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("text-sm font-medium", className)}
+      className={cn(panelTitleClassName, className)}
       {...props}
     />
   )
@@ -47,7 +48,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-xs/relaxed text-muted-foreground", className)}
+      className={cn(panelDescriptionClassName, className)}
       {...props}
     />
   )

--- a/ui/src/pages/Dashboard.test.tsx
+++ b/ui/src/pages/Dashboard.test.tsx
@@ -6,6 +6,7 @@ import Dashboard from "@/pages/Dashboard";
 
 const mockUseAuth = vi.fn();
 const mockGetStatsQuery = vi.fn();
+const mockGetSlowQueriesQuery = vi.fn();
 const mockGetStoragesQuery = vi.fn();
 const mockGetClusterSnapshotQuery = vi.fn();
 const mockCheckStorageHealth = vi.fn();
@@ -17,19 +18,29 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/store/apiSlice", () => ({
   useGetStatsQuery: () => mockGetStatsQuery(),
+  useGetSlowQueriesQuery: () => mockGetSlowQueriesQuery(),
   useGetStoragesQuery: () => mockGetStoragesQuery(),
   useGetClusterSnapshotQuery: () => mockGetClusterSnapshotQuery(),
   useCheckStorageHealthMutation: () => mockCheckStorageHealthMutation(),
 }));
 
 vi.mock("@/components/dashboard/MetricsChart", () => ({
-  MetricsChart: ({ data }: { data: unknown[] }) => <div>Metrics chart {data.length}</div>,
+  MetricsChart: ({ data, trailingPanel }: { data: unknown[]; trailingPanel?: React.ReactNode }) => (
+    <>
+      <div>Metrics chart {data.length}</div>
+      {trailingPanel}
+    </>
+  ),
 }));
 
 vi.mock("@/components/dashboard/StorageUsageChart", () => ({
   StorageUsageChart: ({ selectedStorageId }: { selectedStorageId: string }) => (
     <div>Storage usage {selectedStorageId}</div>
   ),
+}));
+
+vi.mock("@/components/dashboard/SlowQueriesPanel", () => ({
+  SlowQueriesPanel: ({ queries }: { queries: unknown[] }) => <div>Slow query widget {queries.length}</div>,
 }));
 
 vi.mock("@/components/dashboard/ClusterOverview", () => ({
@@ -52,6 +63,7 @@ describe("Dashboard page", () => {
 
     mockUseAuth.mockReset();
     mockGetStatsQuery.mockReset();
+    mockGetSlowQueriesQuery.mockReset();
     mockGetStoragesQuery.mockReset();
     mockGetClusterSnapshotQuery.mockReset();
     mockCheckStorageHealth.mockReset();
@@ -67,9 +79,17 @@ describe("Dashboard page", () => {
         total_namespaces: "9",
         total_tables: "42",
         active_connections: "3",
+        active_connections_peak: "6",
         active_subscriptions: "2",
         active_subscriptions_peak: "7",
-        websocket_sessions_peak: "5",
+        subscription_changes_delivered_per_second: "9.5",
+        pubsub_messages_published_total: "1234",
+        topic_consumer_group_count: "4",
+        topic_cache_topic_count: "8",
+        pubsub_active_consumers: "1",
+        pubsub_messages_consumed_per_second: "3.5",
+        pubsub_messages_consumed_peak_per_second: "12",
+        pubsub_kb_consumed_per_second: "2.75",
         server_uptime_human: "1h 10m",
         queries_total: "12",
         queries_per_second: "1.25",
@@ -88,6 +108,23 @@ describe("Dashboard page", () => {
       },
       isFetching: false,
       error: null,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    });
+
+    mockGetSlowQueriesQuery.mockReturnValue({
+      data: [
+        {
+          timestamp: "2026-05-28T11:00:00Z",
+          timestamp_ms: 1_779_964_800_000,
+          duration_ms: 1200,
+          user_id: "root",
+          table_type: "user",
+          table_name: "events",
+          row_count: 1,
+          query: "SELECT * FROM events",
+        },
+      ],
+      isFetching: false,
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
@@ -165,10 +202,17 @@ describe("Dashboard page", () => {
     expect(screen.getByText("42")).toBeTruthy();
     expect(screen.getByText("9")).toBeTruthy();
     expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("6")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("9.50")).toBeTruthy();
+    expect(screen.getByText("Pub/Sub")).toBeTruthy();
+    expect(screen.getByText("1,234")).toBeTruthy();
+    expect(screen.getByText("4")).toBeTruthy();
+    expect(screen.getByText("8")).toBeTruthy();
     expect(screen.getByText("12")).toBeTruthy();
     expect(screen.getByText("1.25")).toBeTruthy();
     expect(screen.getByText("4.50 ms")).toBeTruthy();
+    expect(screen.getByText("Slow query widget 1")).toBeTruthy();
     expect(screen.getByText("Cluster overview 1")).toBeTruthy();
 
     await waitFor(() => {
@@ -192,6 +236,7 @@ describe("Dashboard page", () => {
 
   it("refreshes dashboard queries and rechecks storage health", async () => {
     const statsRefetch = vi.fn().mockResolvedValue(undefined);
+    const slowQueriesRefetch = vi.fn().mockResolvedValue(undefined);
     const storagesRefetch = vi.fn().mockResolvedValue(undefined);
     const clusterRefetch = vi.fn().mockResolvedValue(undefined);
 
@@ -201,9 +246,17 @@ describe("Dashboard page", () => {
         total_namespaces: "9",
         total_tables: "42",
         active_connections: "3",
+        active_connections_peak: "6",
         active_subscriptions: "2",
         active_subscriptions_peak: "7",
-        websocket_sessions_peak: "5",
+        subscription_changes_delivered_per_second: "9.5",
+        pubsub_messages_published_total: "1234",
+        topic_consumer_group_count: "4",
+        topic_cache_topic_count: "8",
+        pubsub_active_consumers: "1",
+        pubsub_messages_consumed_per_second: "3.5",
+        pubsub_messages_consumed_peak_per_second: "12",
+        pubsub_kb_consumed_per_second: "2.75",
         server_uptime_human: "1h 10m",
         queries_total: "12",
         queries_per_second: "1.25",
@@ -223,6 +276,11 @@ describe("Dashboard page", () => {
       isFetching: false,
       error: null,
       refetch: statsRefetch,
+    });
+    mockGetSlowQueriesQuery.mockReturnValue({
+      data: [],
+      isFetching: false,
+      refetch: slowQueriesRefetch,
     });
     mockGetStoragesQuery.mockReturnValue({
       data: [{ storage_id: "local", name: "Local" }],
@@ -281,6 +339,7 @@ describe("Dashboard page", () => {
 
     await waitFor(() => {
       expect(statsRefetch).toHaveBeenCalledTimes(1);
+      expect(slowQueriesRefetch).toHaveBeenCalledTimes(1);
       expect(storagesRefetch).toHaveBeenCalledTimes(1);
       expect(clusterRefetch).toHaveBeenCalledTimes(1);
       expect(mockCheckStorageHealth).toHaveBeenCalledTimes(2);

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import {
   Clock3,
   Database,
   Gauge,
+  MessageSquare,
   RefreshCw,
   Search,
   Timer,
@@ -19,6 +20,7 @@ import {
 } from "@/components/ui/select";
 import { DashboardClusterOverview } from "@/components/dashboard/ClusterOverview";
 import { MetricsChart } from "@/components/dashboard/MetricsChart";
+import { SlowQueriesPanel } from "@/components/dashboard/SlowQueriesPanel";
 import { StorageUsageChart } from "@/components/dashboard/StorageUsageChart";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { useAuth } from "@/lib/auth";
@@ -31,12 +33,14 @@ import {
 import {
   useCheckStorageHealthMutation,
   useGetClusterSnapshotQuery,
+  useGetSlowQueriesQuery,
   useGetStatsQuery,
   useGetStoragesQuery,
 } from "@/store/apiSlice";
 
 const EMPTY_STATS: SystemStatsMap = {};
 const DASHBOARD_STATS_POLL_INTERVAL_MS = 5000;
+const DASHBOARD_SLOW_QUERIES_POLL_INTERVAL_MS = 15000;
 const HISTORY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const HISTORY_RAW_AGE_MS = 60 * 60 * 1000;
 const HISTORY_MINUTE_AGE_MS = 24 * 60 * 60 * 1000;
@@ -65,6 +69,22 @@ function formatDecimal(value: string | undefined, digits = 2): string {
     minimumFractionDigits: digits,
     maximumFractionDigits: digits,
   });
+}
+
+function cardItemsClass(itemCount: number): string {
+  if (itemCount === 1) {
+    return "flex justify-center";
+  }
+  if (itemCount === 3) {
+    return "grid grid-cols-3 gap-2";
+  }
+  return "grid grid-cols-2 gap-3";
+}
+
+function cardValueClass(itemCount: number): string {
+  return itemCount > 2
+    ? "max-w-full break-words text-center text-xl font-semibold leading-tight tabular-nums"
+    : "max-w-full break-words text-center text-2xl font-semibold leading-tight tabular-nums";
 }
 
 function compactDashboardSamples(samples: DashboardMetricSample[]): DashboardMetricSample[] {
@@ -153,6 +173,15 @@ export default function Dashboard() {
   } = useGetClusterSnapshotQuery(undefined, {
     pollingInterval: 5000,
   });
+  const {
+    data: slowQueries = [],
+    isFetching: isSlowQueriesLoading,
+    refetch: refetchSlowQueries,
+  } = useGetSlowQueriesQuery(10, {
+    pollingInterval: DASHBOARD_SLOW_QUERIES_POLL_INTERVAL_MS,
+    refetchOnFocus: true,
+    refetchOnReconnect: true,
+  });
   const [checkStorageHealth, { data: storageHealth, isLoading: isStorageHealthLoading, error: storageHealthError }] =
     useCheckStorageHealthMutation();
 
@@ -185,7 +214,7 @@ export default function Dashboard() {
   }, [checkStorageHealth, selectedStorageId]);
 
   async function handleRefresh(): Promise<void> {
-    await Promise.all([refetchStats(), refetchStorages(), refetchCluster()]);
+    await Promise.all([refetchStats(), refetchStorages(), refetchCluster(), refetchSlowQueries()]);
 
     if (selectedStorageId) {
       await checkStorageHealth({ storageId: selectedStorageId, extended: true });
@@ -222,9 +251,20 @@ export default function Dashboard() {
       title: "Connections & Subscriptions",
       items: [
         { label: "Connections", value: parseInteger(currentStats.active_connections).toLocaleString() },
+        { label: "Peak Connections", value: parseInteger(currentStats.active_connections_peak).toLocaleString() },
         { label: "Subscriptions", value: parseInteger(currentStats.active_subscriptions).toLocaleString() },
+        { label: "Changes/s", value: formatDecimal(currentStats.subscription_changes_delivered_per_second) },
       ],
       icon: Wifi,
+    },
+    {
+      title: "Pub/Sub",
+      items: [
+        { label: "Messages", value: parseInteger(currentStats.pubsub_messages_published_total).toLocaleString() },
+        { label: "Consumers", value: parseInteger(currentStats.topic_consumer_group_count).toLocaleString() },
+        { label: "Topics", value: parseInteger(currentStats.topic_cache_topic_count).toLocaleString() },
+      ],
+      icon: MessageSquare,
     },
     {
       title: "Queries Total",
@@ -272,19 +312,21 @@ export default function Dashboard() {
         </div>
       }
     >
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-7">
         {cards.map((card) => (
-          <Card key={card.title}>
-            <CardContent className="pt-4">
-              <div className="mb-2 flex items-center justify-between">
-                <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{card.title}</p>
-                <card.icon className="h-4 w-4 text-muted-foreground" />
+          <Card key={card.title} className="min-h-[142px]">
+            <CardContent className="flex flex-1 flex-col justify-center text-center">
+              <div className="relative mb-3 flex min-h-8 items-start justify-center px-5">
+                <p className="text-center text-xs uppercase leading-snug tracking-[0.14em] text-muted-foreground">
+                  {card.title}
+                </p>
+                <card.icon className="absolute right-0 top-0 h-4 w-4 text-muted-foreground" />
               </div>
-              <div className={card.items.length > 1 ? "grid grid-cols-2 gap-3" : ""}>
+              <div className={cardItemsClass(card.items.length)}>
                 {card.items.map((item) => (
-                  <div key={item.label} className="min-w-0">
-                    <p className="truncate text-2xl font-semibold">{item.value}</p>
-                    <p className="truncate text-xs text-muted-foreground">{item.label}</p>
+                  <div key={item.label} className="flex min-w-0 flex-col items-center text-center">
+                    <p className={cardValueClass(card.items.length)}>{item.value}</p>
+                    <p className="text-center text-xs leading-snug text-muted-foreground">{item.label}</p>
                   </div>
                 ))}
               </div>
@@ -293,7 +335,11 @@ export default function Dashboard() {
         ))}
       </div>
 
-      <MetricsChart data={visibleMetricSamples} isLoading={isLoading && visibleMetricSamples.length === 0} />
+      <MetricsChart
+        data={visibleMetricSamples}
+        isLoading={isLoading && visibleMetricSamples.length === 0}
+        trailingPanel={<SlowQueriesPanel queries={slowQueries} isLoading={isSlowQueriesLoading && slowQueries.length === 0} />}
+      />
 
       <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.95fr)]">
         <StorageUsageChart

--- a/ui/src/pages/Logging.tsx
+++ b/ui/src/pages/Logging.tsx
@@ -2,6 +2,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { AuditLogList } from "@/components/audit/AuditLogList";
 import { JobList } from "@/components/jobs/JobList";
 import { ServerLogList } from "@/components/logs/ServerLogList";
+import { PageHeader } from "@/components/layout/typography";
 import { cn } from "@/lib/utils";
 
 type LogTab = "audit" | "jobs" | "server";
@@ -42,10 +43,7 @@ export default function Logging() {
     <div className="flex flex-col h-full">
       {/* Tab Navigation */}
       <div className="border-b px-4 lg:px-6 pt-4">
-        <div className="mb-4">
-          <h1 className="text-2xl font-semibold tracking-tight">Logging</h1>
-          <p className="text-sm text-muted-foreground">{activeTabData.description}</p>
-        </div>
+        <PageHeader title="Logging" description={activeTabData.description} className="mb-4" />
         <nav className="flex gap-4">
           {tabs.map((tabItem) => (
             <button

--- a/ui/src/pages/SqlStudio.test.tsx
+++ b/ui/src/pages/SqlStudio.test.tsx
@@ -754,7 +754,7 @@ describe("SqlStudio page", () => {
     });
 
     fireEvent.click(screen.getByRole("switch"));
-    fireEvent.click(screen.getByTitle("Subscription options"));
+    fireEvent.click(screen.getByRole("button", { name: /subscription options/i }));
     fireEvent.change(screen.getByLabelText("from"), {
       target: { value: "9223372036854775807" },
     });

--- a/ui/src/pages/SqlStudio.tsx
+++ b/ui/src/pages/SqlStudio.tsx
@@ -1229,8 +1229,8 @@ export default function SqlStudio() {
                   <div className="absolute right-2 top-1.5 z-20">
                     <Button
                       variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                      size="icon-sm"
+                      className="text-muted-foreground hover:text-foreground"
                       onClick={toggleInspector}
                       title={isInspectorCollapsed ? "Expand details panel" : "Collapse details panel"}
                     >

--- a/ui/src/pages/StreamingGroups.tsx
+++ b/ui/src/pages/StreamingGroups.tsx
@@ -81,7 +81,7 @@ export default function StreamingGroups() {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Consumer Groups</CardTitle>
+          <CardTitle>Consumer Groups</CardTitle>
           <CardDescription>
             {filteredGroups.length} group{filteredGroups.length === 1 ? "" : "s"} visible
           </CardDescription>

--- a/ui/src/pages/StreamingOffsets.tsx
+++ b/ui/src/pages/StreamingOffsets.tsx
@@ -16,6 +16,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { fieldLabelClassName } from "@/components/layout/typography";
 import {
   Table,
   TableBody,
@@ -248,12 +249,12 @@ export default function StreamingOffsets() {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Filters</CardTitle>
+          <CardTitle>Filters</CardTitle>
           <CardDescription>Limit the combined consumer cursor list by topic and/or group</CardDescription>
         </CardHeader>
         <CardContent className="grid gap-3 md:grid-cols-2">
           <div className="space-y-1">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Topic</p>
+            <p className={fieldLabelClassName}>Topic</p>
             <Select value={selectedTopic} onValueChange={setSelectedTopic}>
               <SelectTrigger>
                 <SelectValue placeholder="All topics" />
@@ -267,7 +268,7 @@ export default function StreamingOffsets() {
             </Select>
           </div>
           <div className="space-y-1">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Group</p>
+            <p className={fieldLabelClassName}>Group</p>
             <Select value={selectedGroup} onValueChange={setSelectedGroup}>
               <SelectTrigger>
                 <SelectValue placeholder="All groups" />
@@ -299,7 +300,7 @@ export default function StreamingOffsets() {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Consumers</CardTitle>
+          <CardTitle>Consumers</CardTitle>
           <CardDescription>
             {filteredSummaries.length} group-topic row{filteredSummaries.length === 1 ? "" : "s"} returned. Partitions show claimed/configured coverage.
           </CardDescription>
@@ -359,8 +360,7 @@ export default function StreamingOffsets() {
               <div className="flex items-center gap-1">
                 <Button
                   variant="outline"
-                  size="icon"
-                  className="h-8 w-8"
+                  size="icon-sm"
                   disabled={page === 0}
                   onClick={() => setPage((currentPage) => Math.max(0, currentPage - 1))}
                 >
@@ -369,8 +369,7 @@ export default function StreamingOffsets() {
                 <span className="px-2 text-sm text-muted-foreground">{page + 1} / {totalPages}</span>
                 <Button
                   variant="outline"
-                  size="icon"
-                  className="h-8 w-8"
+                  size="icon-sm"
                   disabled={page >= totalPages - 1}
                   onClick={() => setPage((currentPage) => Math.min(totalPages - 1, currentPage + 1))}
                 >

--- a/ui/src/pages/StreamingTopicDetail.tsx
+++ b/ui/src/pages/StreamingTopicDetail.tsx
@@ -37,6 +37,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fieldLabelClassName } from "@/components/layout/typography";
 import { formatDate, formatTimestamp } from "@/lib/formatters";
 
 function formatNullableTimestamp(value: string | null): string {
@@ -256,24 +257,24 @@ export default function StreamingTopicDetail() {
         <>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-base">Topic Summary</CardTitle>
+              <CardTitle>Topic Summary</CardTitle>
               <CardDescription className="font-mono text-xs">{selectedTopic.topicId}</CardDescription>
             </CardHeader>
             <CardContent className="grid gap-3 md:grid-cols-4">
               <div>
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Partitions</p>
+                <p className={fieldLabelClassName}>Partitions</p>
                 <p className="font-medium">{selectedTopic.partitions}</p>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Routes</p>
+                <p className={fieldLabelClassName}>Routes</p>
                 <p className="font-medium">{selectedTopic.routeCount}</p>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Created</p>
+                <p className={fieldLabelClassName}>Created</p>
                 <p className="font-mono text-xs">{formatNullableTimestamp(selectedTopic.createdAt)}</p>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Updated</p>
+                <p className={fieldLabelClassName}>Updated</p>
                 <p className="font-mono text-xs">{formatNullableTimestamp(selectedTopic.updatedAt)}</p>
               </div>
             </CardContent>
@@ -318,7 +319,7 @@ export default function StreamingTopicDetail() {
             <TabsContent value="messages" className="mt-0 flex flex-col gap-4">
               <Card>
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-base">Inspect Messages</CardTitle>
+                  <CardTitle>Inspect Messages</CardTitle>
                   <CardDescription>{messages.length} row{messages.length === 1 ? "" : "s"} in the current inspector result</CardDescription>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-4">
@@ -334,7 +335,7 @@ export default function StreamingTopicDetail() {
 
                     <div className="grid gap-3 md:grid-cols-6">
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Mode</p>
+                        <p className={fieldLabelClassName}>Mode</p>
                         <Select value={readMode} onValueChange={(value) => setReadMode(value as ConsumeReadMode)}>
                           <SelectTrigger aria-label="Mode">
                             <SelectValue />
@@ -348,7 +349,7 @@ export default function StreamingTopicDetail() {
                         </Select>
                       </div>
                       <div className="flex flex-col gap-1 md:col-span-2">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Group ID</p>
+                        <p className={fieldLabelClassName}>Group ID</p>
                         <Input
                           aria-label="Group ID"
                           value={groupId}
@@ -357,7 +358,7 @@ export default function StreamingTopicDetail() {
                         />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Partition</p>
+                        <p className={fieldLabelClassName}>Partition</p>
                         <Select value={partitionId} onValueChange={setPartitionId}>
                           <SelectTrigger aria-label="Partition">
                             <SelectValue placeholder={partitionOptions[0] ?? "0"} />
@@ -372,7 +373,7 @@ export default function StreamingTopicDetail() {
                         </Select>
                       </div>
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Start</p>
+                        <p className={fieldLabelClassName}>Start</p>
                         <Select value={startMode} onValueChange={(value) => setStartMode(value as ConsumeStartMode)}>
                           <SelectTrigger aria-label="Start">
                             <SelectValue />
@@ -387,7 +388,7 @@ export default function StreamingTopicDetail() {
                         </Select>
                       </div>
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Offset</p>
+                        <p className={fieldLabelClassName}>Offset</p>
                         <Input
                           aria-label="Offset"
                           value={offsetValue}
@@ -396,15 +397,15 @@ export default function StreamingTopicDetail() {
                         />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Limit</p>
+                        <p className={fieldLabelClassName}>Limit</p>
                         <Input aria-label="Limit" value={limitValue} onChange={(event) => setLimitValue(event.target.value)} />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Timeout (s)</p>
+                        <p className={fieldLabelClassName}>Timeout (s)</p>
                         <Input aria-label="Timeout" value={timeoutValue} onChange={(event) => setTimeoutValue(event.target.value)} />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Decode</p>
+                        <p className={fieldLabelClassName}>Decode</p>
                         <Select value={decodeMode} onValueChange={(value) => setDecodeMode(value as PayloadDecodeMode)}>
                           <SelectTrigger aria-label="Decode">
                             <SelectValue />
@@ -552,7 +553,7 @@ export default function StreamingTopicDetail() {
             <TabsContent value="offsets" className="mt-0">
               <Card>
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-base">Committed Offsets</CardTitle>
+                  <CardTitle>Committed Offsets</CardTitle>
                   <CardDescription>{offsets.length} row{offsets.length === 1 ? "" : "s"} for {selectedTopic.topicId}</CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -595,7 +596,7 @@ export default function StreamingTopicDetail() {
             <TabsContent value="sql" className="mt-0">
               <Card>
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-base">SQL Studio Shortcuts</CardTitle>
+                  <CardTitle>SQL Studio Shortcuts</CardTitle>
                   <CardDescription>Each shortcut opens SQL Studio with the exact query shown beside it.</CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-3">

--- a/ui/src/pages/StreamingTopics.tsx
+++ b/ui/src/pages/StreamingTopics.tsx
@@ -126,7 +126,7 @@ export default function StreamingTopics() {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Topics</CardTitle>
+          <CardTitle>Topics</CardTitle>
           <CardDescription>
             {sortedTopics.length} topic{sortedTopics.length === 1 ? "" : "s"} visible
           </CardDescription>

--- a/ui/src/services/systemTableService.test.ts
+++ b/ui/src/services/systemTableService.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchSystemStats } from "@/services/systemTableService";
+
+const mockGetDb = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => mockGetDb(),
+}));
+
+vi.mock("@/lib/schema", () => ({
+  system_settings: Symbol("system_settings"),
+  system_slow_queries: Symbol("system_slow_queries"),
+  system_stats: Symbol("system_stats"),
+}));
+
+describe("fetchSystemStats", () => {
+  it("returns all available system.stats rows without truncating to 100", async () => {
+    const rows = Array.from({ length: 150 }, (_, index) => ({
+      metric_name: `metric_${index + 1}`,
+      metric_value: index + 1,
+    }));
+
+    const limit = vi.fn().mockResolvedValue(rows.slice(0, 100));
+    const from = vi.fn().mockImplementation(async (resolve: (value: typeof rows) => unknown) => resolve(rows));
+
+    mockGetDb.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          then: from,
+          limit,
+        }),
+      }),
+    });
+
+    const stats = await fetchSystemStats();
+
+    expect(Object.keys(stats)).toHaveLength(150);
+    expect(stats.metric_150).toBe("150");
+    expect(limit).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/services/systemTableService.ts
+++ b/ui/src/services/systemTableService.ts
@@ -33,7 +33,7 @@ export function mapSettingsRows(rows: Setting[]): Setting[] {
 
 export async function fetchSystemStats(): Promise<SystemStatsMap> {
   const db = getDb();
-  const rows = await db.select().from(system_stats).limit(100);
+  const rows = await db.select().from(system_stats).limit(150);
   const stats: SystemStatsMap = {};
   for (const row of rows) {
     if (row.metric_name) {
@@ -45,9 +45,15 @@ export async function fetchSystemStats(): Promise<SystemStatsMap> {
 
 export const DASHBOARD_METRIC_KEYS = [
   "active_connections",
+  "active_connections_peak",
   "active_subscriptions",
   "active_subscriptions_peak",
-  "websocket_sessions_peak",
+  "subscription_changes_delivered_per_second",
+  "pubsub_active_consumers",
+  "pubsub_messages_consumed_per_second",
+  "pubsub_messages_consumed_peak_per_second",
+  "pubsub_kb_consumed_per_second",
+  "topic_cache_topic_count",
   "memory_usage_mb",
   "cpu_usage_percent",
   "select_queries_per_second",

--- a/ui/tests/e2e/table-editor-options.spec.ts
+++ b/ui/tests/e2e/table-editor-options.spec.ts
@@ -234,7 +234,7 @@ async function mockAdminApi(page: Page, executedSql: string[]) {
                 ttl_seconds: 7200,
                 eviction_strategy: "hybrid",
                 max_stream_size_bytes: 1048576,
-                compression: "lz4",
+                compression: "zstd",
               },
               columns: [
                 {
@@ -287,7 +287,7 @@ test("admin creates a stream table with stream-specific options", async ({
   await page.getByTestId("table-option-ttl-seconds").fill("7200");
   await chooseSelect(page, "table-option-eviction-strategy", /^hybrid$/i);
   await page.getByTestId("table-option-max-stream-size").fill("1048576");
-  await chooseSelect(page, "table-option-compression", /^lz4$/i);
+  await expect(page.getByTestId("table-option-compression")).toHaveCount(0);
 
   await page.getByRole("button", { name: /review & create/i }).click();
   await page.getByRole("button", { name: /^commit$/i }).click();
@@ -300,7 +300,7 @@ test("admin creates a stream table with stream-specific options", async ({
   expect(createSql).toContain("TTL_SECONDS = 7200");
   expect(createSql).toContain("EVICTION_STRATEGY = 'hybrid'");
   expect(createSql).toContain("MAX_STREAM_SIZE_BYTES = 1048576");
-  expect(createSql).toContain("COMPRESSION = 'lz4'");
+  expect(createSql).not.toContain("COMPRESSION");
 });
 
 test("admin edits shared table options", async ({ page }) => {
@@ -313,7 +313,7 @@ test("admin edits shared table options", async ({ page }) => {
   await chooseSelect(page, "table-option-flush-policy", /^combined$/i);
   await page.getByTestId("table-option-flush-rows").fill("2000");
   await page.getByTestId("table-option-flush-interval").fill("120");
-  await chooseSelect(page, "table-option-compression", /^zstd$/i);
+  await chooseSelect(page, "table-option-compression", /^none$/i);
 
   await page.getByRole("button", { name: /review & save/i }).click();
   await page.getByRole("button", { name: /^commit$/i }).click();
@@ -324,5 +324,5 @@ test("admin edits shared table options", async ({ page }) => {
   const alterSql = executedSql.find((sql) => /alter\s+table/i.test(sql)) ?? "";
   expect(alterSql).toContain("ACCESS_LEVEL = 'PUBLIC'");
   expect(alterSql).toContain("FLUSH_POLICY = 'rows:2000,interval:120'");
-  expect(alterSql).toContain("COMPRESSION = 'zstd'");
+  expect(alterSql).toContain("COMPRESSION = 'none'");
 });


### PR DESCRIPTION
Integrate kalamdb-observability and traceability across the codebase and replace string-based compression with a typed TableCompression enum.

- Add kalamdb-observability crate usages and enable a workspace-level `traceability` feature path to wire observability into backend features.
- Replace table option compression (String) with TableCompression enum, provide serde/fromstr/display impls, default value, and tests; expose parquet_compression getter where needed.
- Switch tracing spans/metrics to kalamdb_observability helpers (kdb_debug*, kdb_record_current_span!, kdb_await_in_info_span!), and add topic consumer metrics fields.
- Refactor raft blocking helpers: add run_blocking_raft utility and replace repetitive tokio::task::spawn_blocking usage with it, simplifying error handling.
- Adjust cached table data to keep Bloom filters limited to primary key columns and update related tests.
- Small refactors: collect batch rows before validation, minor API and test updates, and new observability-related modules and tests.
