### PR TITLE
admin-ui: lazy-load Monaco out of SqlStudio chunk + schema loader

### DIFF
--- a/ui/src/components/sql-studio-v2/browser-tree/StudioExplorerPanel.tsx
+++ b/ui/src/components/sql-studio-v2/browser-tree/StudioExplorerPanel.tsx
@@ -5,6 +5,7 @@ import {
   Database,
   FolderTree,
   KeyRound,
+  Loader2,
   RefreshCw,
   Radio,
   Search,
@@ -232,8 +233,15 @@ const StudioExplorerPanelComponent = ({
               {namespaceSectionExpanded && (
                 <div className="space-y-0.5 mt-0.5 pb-2">
                   {filteredSchema.length === 0 && (
-                    <div className="px-8 py-1.5 text-xs text-muted-foreground">
-                      No matching namespaces or tables.
+                    <div className="flex items-center px-8 py-1.5 text-xs text-muted-foreground">
+                      {schema.length === 0 && isRefreshing ? (
+                        <>
+                          <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                          Loading schema…
+                        </>
+                      ) : (
+                        "No matching namespaces or tables."
+                      )}
                     </div>
                   )}
                   {filteredSchema.map((namespace) => {

--- a/ui/src/components/sql-studio-v2/input-form/EditorSkeleton.tsx
+++ b/ui/src/components/sql-studio-v2/input-form/EditorSkeleton.tsx
@@ -1,0 +1,19 @@
+import { Loader2 } from "lucide-react";
+
+export function EditorSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
+        <div className="space-y-1.5">
+          <div className="h-4 w-40 animate-pulse rounded bg-muted/60" />
+          <div className="h-3 w-14 animate-pulse rounded bg-muted/40" />
+        </div>
+        <div className="h-7 w-20 animate-pulse rounded bg-muted/40" />
+      </div>
+      <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+        <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+        Loading editor…
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/SqlStudio.tsx
+++ b/ui/src/pages/SqlStudio.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, startTransition, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { PanelRightClose, PanelRightOpen } from "lucide-react";
 import { StudioExplorerPanel } from "@/components/sql-studio-v2/browser-tree/StudioExplorerPanel";
@@ -14,7 +14,12 @@ import { useToast } from "@/components/ui/toaster-provider";
 import { useSqlPreview } from "@/components/sql-preview";
 
 import { QueryTabStrip } from "@/components/sql-studio-v2/input-form/QueryTabStrip";
-import { StudioEditorPanel } from "@/components/sql-studio-v2/input-form/StudioEditorPanel";
+import { EditorSkeleton } from "@/components/sql-studio-v2/input-form/EditorSkeleton";
+const StudioEditorPanel = lazy(() =>
+  import("@/components/sql-studio-v2/input-form/StudioEditorPanel").then((m) => ({
+    default: m.StudioEditorPanel,
+  })),
+);
 import { StudioInspectorPanel } from "@/components/sql-studio-v2/inspector/StudioInspectorPanel";
 import { StudioResultsGrid } from "@/components/sql-studio-v2/preview/StudioResultsGrid";
 import { Button } from "@/components/ui/button";
@@ -1264,6 +1269,7 @@ export default function SqlStudio() {
                     dispatch(setVerticalLayout([safeSize, 100 - safeSize]));
                   }}
                 >
+                  <Suspense fallback={<EditorSkeleton />}>
                   <StudioEditorPanel
                     schema={schema}
                     tabTitle={activeTab.title}
@@ -1290,6 +1296,7 @@ export default function SqlStudio() {
                     onSaveCopy={() => saveTab(activeTab.id, true)}
                     onDelete={deleteActiveTab}
                   />
+                  </Suspense>
                 </ResizablePanel>
 
                 <ResizableHandle withHandle />


### PR DESCRIPTION
SQL Studio's first paint was slow because Monaco (~3MB via @monaco-editor/react) was bundled into the main SqlStudio chunk. Now it's lazy-loaded with a skeleton fallback, and the Explorer panel shows "Loading schema…" instead of looking empty during the first fetch.

Three files: SqlStudio.tsx, EditorSkeleton.tsx (new), StudioExplorerPanel.tsx.