### PR TITLE
Release 0.5.6-rc.0: faster SQL and auth hot paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ on:
         required: false
         default: true
 
+      release_description:
+        description: "GitHub release notes (markdown). If set, used as the release body instead of auto-generated notes."
+        type: string
+        required: false
+        default: ""
+
       docker_push:
         description: "Push Docker images to Docker Hub and GitHub Container Registry"
         type: boolean
@@ -1769,13 +1775,31 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Prepare release notes
+        id: release_notes
+        env:
+          RELEASE_DESCRIPTION: ${{ github.event.inputs.release_description }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          NOTES_PATH="$RUNNER_TEMP/release-notes.md"
+          if [[ -n "${RELEASE_DESCRIPTION//[$' \t\r\n']}" ]]; then
+            printf '%s\n' "$RELEASE_DESCRIPTION" > "$NOTES_PATH"
+            echo "body_path=$NOTES_PATH" >> "$GITHUB_OUTPUT"
+            echo "generate=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "body_path=" >> "$GITHUB_OUTPUT"
+            echo "generate=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.read_version.outputs.tag }}
           target_commitish: ${{ needs.sync_versions_manifest.outputs.commit_sha }}
           prerelease: ${{ steps.prerelease_flag.outputs.prerelease }}
-          generate_release_notes: true
+          body_path: ${{ steps.release_notes.outputs.body_path }}
+          generate_release_notes: ${{ steps.release_notes.outputs.generate }}
           files: |
             dist/${{ needs.read_version.outputs.version }}/*.tar.gz
             dist/${{ needs.read_version.outputs.version }}/*.zip

--- a/backend/crates/kalamdb-api/src/http/sql/helpers/schema_response_cache.rs
+++ b/backend/crates/kalamdb-api/src/http/sql/helpers/schema_response_cache.rs
@@ -11,22 +11,33 @@ use std::{
 };
 
 use arrow::datatypes::SchemaRef;
-use kalamdb_commons::{
-    conversions::schema_fields_from_arrow_schema, schemas::SchemaField,
-};
+use bytes::Bytes;
+use kalamdb_commons::{conversions::schema_fields_from_arrow_schema, schemas::SchemaField};
 use moka::sync::Cache;
+
+const ROW_RESULT_PREFIX_HEAD: &str = "{\"status\":\"success\",\"results\":[{\"schema\":";
+const ROW_RESULT_PREFIX_TAIL: &str = ",\"rows\":[";
 
 /// Cached API schema projection for a given Arrow schema shape.
 #[derive(Clone)]
 pub struct CachedSqlSchema {
     pub fields: Arc<Vec<SchemaField>>,
-    /// `serde_json` serialization of `fields` (the `"schema": [...]` array body).
-    pub schema_json: Arc<str>,
+    /// Prebuilt streaming/inline JSON prefix through `"rows":[`.
+    pub row_result_prefix: Bytes,
 }
 
-static SCHEMA_RESPONSE_CACHE: LazyLock<Cache<u64, Arc<CachedSqlSchema>>> = LazyLock::new(|| {
-    Cache::builder().max_capacity(512).build()
-});
+fn row_result_prefix_bytes(schema_json: &str) -> Bytes {
+    let mut prefix = String::with_capacity(
+        ROW_RESULT_PREFIX_HEAD.len() + schema_json.len() + ROW_RESULT_PREFIX_TAIL.len(),
+    );
+    prefix.push_str(ROW_RESULT_PREFIX_HEAD);
+    prefix.push_str(schema_json);
+    prefix.push_str(ROW_RESULT_PREFIX_TAIL);
+    Bytes::from(prefix)
+}
+
+static SCHEMA_RESPONSE_CACHE: LazyLock<Cache<u64, Arc<CachedSqlSchema>>> =
+    LazyLock::new(|| Cache::builder().max_capacity(512).build());
 
 fn schema_fingerprint(schema: &arrow::datatypes::Schema) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -57,7 +68,7 @@ pub fn cached_sql_schema(schema: &SchemaRef) -> Arc<CachedSqlSchema> {
     let schema_json = serde_json::to_string(&fields).unwrap_or_else(|_| "[]".to_string());
     let entry = Arc::new(CachedSqlSchema {
         fields: Arc::new(fields),
-        schema_json: Arc::from(schema_json),
+        row_result_prefix: row_result_prefix_bytes(&schema_json),
     });
     SCHEMA_RESPONSE_CACHE.insert(key, Arc::clone(&entry));
     entry
@@ -81,7 +92,10 @@ mod tests {
         let first = cached_sql_schema(&schema);
         let second = cached_sql_schema(&schema);
         assert!(Arc::ptr_eq(&first, &second));
-        assert!(first.schema_json.contains("\"id\""));
         assert_eq!(first.fields.len(), 2);
+        let prefix = std::str::from_utf8(&first.row_result_prefix).expect("utf8 prefix");
+        assert!(prefix.contains("\"id\""));
+        assert!(prefix.starts_with("{\"status\":\"success\""));
+        assert!(prefix.ends_with(",\"rows\":["));
     }
 }

--- a/backend/crates/kalamdb-api/src/http/sql/helpers/streaming.rs
+++ b/backend/crates/kalamdb-api/src/http/sql/helpers/streaming.rs
@@ -9,8 +9,12 @@ use kalamdb_commons::{
 use kalamdb_core::providers::arrow_json_conversion::record_batch_to_json_arrays;
 use std::sync::Arc;
 
-use super::converter::{resolve_arrow_schema, row_result_prefix_from_json, success_response_suffix};
+use super::converter::{resolve_arrow_schema, success_response_suffix};
 use super::schema_response_cache::cached_sql_schema;
+
+/// Point lookups and other tiny SELECT results fit in one HTTP body. Streaming
+/// those as three chunks pays extra framing for no benefit.
+const INLINE_SQL_ROWS_MAX: usize = 32;
 
 struct StreamingRowsState {
     prefix: Option<Bytes>,
@@ -42,6 +46,51 @@ fn serialize_rows_chunk(
     Ok(Some(Bytes::from(chunk)))
 }
 
+fn append_serialized_rows(
+    dest: &mut Vec<u8>,
+    rows: &[Vec<KalamCellValue>],
+    row_separator_needed: &mut bool,
+) -> Result<(), serde_json::Error> {
+    if let Some(chunk) = serialize_rows_chunk(rows, row_separator_needed)? {
+        dest.extend_from_slice(&chunk);
+    }
+    Ok(())
+}
+
+fn batches_to_masked_rows(
+    batches: &[arrow::record_batch::RecordBatch],
+    schema_fields: &[SchemaField],
+    user_role: Option<Role>,
+) -> Result<Vec<Vec<KalamCellValue>>, actix_web::Error> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let mut batch_rows =
+            record_batch_to_json_arrays(batch).map_err(ErrorInternalServerError)?;
+        if let Some(role) = user_role {
+            mask_sensitive_rows_for_role(&mut batch_rows, schema_fields, role);
+        }
+        rows.append(&mut batch_rows);
+    }
+    Ok(rows)
+}
+
+fn inline_sql_rows_body(
+    batches: &[arrow::record_batch::RecordBatch],
+    prefix: &Bytes,
+    schema_fields: &[SchemaField],
+    user_role: Option<Role>,
+    suffix: &str,
+) -> Result<Bytes, actix_web::Error> {
+    let rows = batches_to_masked_rows(batches, schema_fields, user_role)?;
+    let mut body = Vec::with_capacity(prefix.len() + suffix.len() + rows.len() * 64);
+    body.extend_from_slice(prefix);
+    let mut row_separator_needed = false;
+    append_serialized_rows(&mut body, &rows, &mut row_separator_needed)
+        .map_err(ErrorInternalServerError)?;
+    body.extend_from_slice(suffix.as_bytes());
+    Ok(Bytes::from(body))
+}
+
 pub fn stream_sql_rows_response(
     batches: Vec<arrow::record_batch::RecordBatch>,
     schema: Option<arrow::datatypes::SchemaRef>,
@@ -53,15 +102,24 @@ pub fn stream_sql_rows_response(
     let arrow_schema = resolve_arrow_schema(&batches, schema)
         .ok_or_else(|| ErrorInternalServerError("Missing schema for row response"))?;
     let cached = cached_sql_schema(&arrow_schema);
+    let suffix = success_response_suffix(row_count, &as_user, took);
 
-    let prefix = Bytes::from(row_result_prefix_from_json(&cached.schema_json));
-    let suffix = Bytes::from(success_response_suffix(row_count, &as_user, took));
+    if row_count <= INLINE_SQL_ROWS_MAX {
+        let body = inline_sql_rows_body(
+            &batches,
+            &cached.row_result_prefix,
+            cached.fields.as_ref(),
+            user_role,
+            &suffix,
+        )?;
+        return Ok(HttpResponse::Ok().content_type("application/json").body(body));
+    }
 
     let response_stream = stream::unfold(
         StreamingRowsState {
-            prefix: Some(prefix),
+            prefix: Some(cached.row_result_prefix.clone()),
             batches: batches.into_iter(),
-            suffix: Some(suffix),
+            suffix: Some(Bytes::from(suffix)),
             schema_fields: Arc::clone(&cached.fields),
             user_role,
             row_separator_needed: false,
@@ -92,4 +150,40 @@ pub fn stream_sql_rows_response(
     );
 
     Ok(HttpResponse::Ok().content_type("application/json").streaming(response_stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{Int64Array, RecordBatch},
+        datatypes::{DataType, Field, Schema},
+    };
+
+    use super::*;
+
+    #[test]
+    fn inline_body_is_valid_json_for_one_row() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let batch =
+            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int64Array::from(vec![7]))])
+                .expect("batch");
+        let cached = cached_sql_schema(&schema);
+        let suffix = success_response_suffix(1, "dba", 0.125);
+        let body = inline_sql_rows_body(
+            &[batch],
+            &cached.row_result_prefix,
+            cached.fields.as_ref(),
+            None,
+            &suffix,
+        )
+        .expect("inline body");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).expect("inline SQL body must be JSON");
+        assert_eq!(parsed["status"], "success");
+        assert_eq!(parsed["results"][0]["row_count"], 1);
+        assert_eq!(parsed["results"][0]["as_user"], "dba");
+        assert_eq!(parsed["results"][0]["rows"][0][0], "7");
+    }
 }

--- a/backend/crates/kalamdb-auth/src/helpers/extractor.rs
+++ b/backend/crates/kalamdb-auth/src/helpers/extractor.rs
@@ -34,13 +34,13 @@
 
 use std::{fmt, future::Future, pin::Pin, sync::Arc};
 
-use actix_web::{dev::Payload, http::StatusCode, FromRequest, HttpRequest, ResponseError};
 use crate::{
     errors::error::AuthError,
     helpers::ip_extractor::extract_client_ip_secure,
     repository::user_repo::UserRepository,
-    services::unified::{authenticate, AuthRequest},
+    services::unified::{authenticate, try_cached_bearer_session, AuthRequest},
 };
+use actix_web::{dev::Payload, http::StatusCode, FromRequest, HttpRequest, ResponseError};
 
 /// Error type for authentication extraction.
 ///
@@ -294,11 +294,50 @@ impl From<AuthSessionExtractor> for kalamdb_session::AuthSession {
     }
 }
 
+fn request_id_from_headers(req: &HttpRequest) -> Option<Arc<str>> {
+    req.headers()
+        .get("X-Request-ID")
+        .and_then(|h| h.to_str().ok())
+        .map(Arc::<str>::from)
+}
+
+fn session_from_authenticated_user(
+    user: crate::models::context::AuthenticatedUser,
+    connection_info: kalamdb_commons::models::ConnectionInfo,
+    request_id: Option<Arc<str>>,
+) -> AuthSessionExtractor {
+    let mut session = kalamdb_session::AuthSession::with_auth_details(
+        user.user_id,
+        user.role,
+        connection_info,
+        kalamdb_session::AuthMethod::Bearer,
+    );
+    if let Some(rid) = request_id {
+        session = session.with_request_id(rid);
+    }
+    AuthSessionExtractor(session)
+}
+
+fn try_extract_cached_bearer_session(req: &HttpRequest) -> Option<AuthSessionExtractor> {
+    let auth_header = req.headers().get("Authorization")?.to_str().ok()?;
+    let connection_info = extract_client_ip_secure(req);
+    let user = try_cached_bearer_session(auth_header, &connection_info)?;
+    Some(session_from_authenticated_user(
+        user,
+        connection_info,
+        request_id_from_headers(req),
+    ))
+}
+
 impl FromRequest for AuthSessionExtractor {
     type Error = AuthExtractError;
     type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        if let Some(extractor) = try_extract_cached_bearer_session(req) {
+            return Box::pin(std::future::ready(Ok(extractor)));
+        }
+
         let req = req.clone();
 
         Box::pin(async move {

--- a/backend/crates/kalamdb-auth/src/lib.rs
+++ b/backend/crates/kalamdb-auth/src/lib.rs
@@ -53,7 +53,7 @@ pub use services::{
     session_tokens::{issue_auth_tokens, IssuedAuthTokens},
     unified::{
         authenticate, authenticate_wire_password, extract_user_id_for_audit,
-        resolve_refresh_token_user, AuthRequest, AuthenticationResult, WireAuthResult,
-        WirePasswordAuthRequest,
+        invalidate_bearer_sessions, resolve_refresh_token_user, try_cached_bearer_session,
+        AuthRequest, AuthenticationResult, WireAuthResult, WirePasswordAuthRequest,
     },
 };

--- a/backend/crates/kalamdb-auth/src/repository/user_repo.rs
+++ b/backend/crates/kalamdb-auth/src/repository/user_repo.rs
@@ -5,6 +5,7 @@ use kalamdb_system::{User, UsersTableProvider};
 use moka::sync::Cache;
 
 use crate::errors::error::AuthResult;
+use crate::services::unified::invalidate_bearer_sessions;
 
 /// Abstraction over user persistence for authentication flows.
 ///
@@ -56,6 +57,7 @@ impl CachedUsersRepo {
 
     pub fn invalidate_user(&self, user_id: &UserId) {
         self.cache.invalidate(user_id);
+        invalidate_bearer_sessions(user_id);
     }
 
     pub fn clear_cache(&self) {

--- a/backend/crates/kalamdb-auth/src/services/unified/bearer.rs
+++ b/backend/crates/kalamdb-auth/src/services/unified/bearer.rs
@@ -16,11 +16,17 @@ use crate::{
     repository::user_repo::UserRepository,
 };
 
+use super::bearer_session_cache::{lookup_cached_bearer_session, store_cached_bearer_session};
+
 pub(super) async fn authenticate_bearer(
     token: &str,
     connection_info: &ConnectionInfo,
     repo: &Arc<dyn UserRepository>,
 ) -> AuthResult<AuthenticatedUser> {
+    if let Some(cached) = lookup_cached_bearer_session(token, connection_info) {
+        return Ok(cached);
+    }
+
     let span = tracing::info_span!(
         "auth.bearer",
         token_len = token.len(),
@@ -88,6 +94,8 @@ pub(super) async fn authenticate_bearer(
         let role = user.role;
 
         tracing::trace!(user_id = %user.user_id, role = ?role, "Bearer authentication succeeded");
+
+        store_cached_bearer_session(token, &user, claims.exp);
 
         Ok(user)
     }
@@ -803,5 +811,67 @@ mod tests {
         assert_eq!(user.user_id, user_id);
         assert_eq!(user.role, Role::User);
         assert_eq!(user.auth_type, AuthType::Oidc);
+    }
+
+    fn bearer_cache_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn init_bearer_cache_jwt(secret: &str) {
+        jwt_config::init_jwt_config(secret, jwt_auth::KALAMDB_ISSUER, None, false, Role::User);
+        super::super::bearer_session_cache::clear_bearer_session_cache();
+    }
+
+    #[tokio::test]
+    async fn authenticate_bearer_reuses_verified_session_without_second_user_lookup() {
+        let _guard = bearer_cache_test_lock();
+        let secret = "bearer-session-cache-test-secret-32ch";
+        init_bearer_cache_jwt(secret);
+
+        let user_id = UserId::new("bearer_cache_user");
+        let stored = test_user(user_id.clone(), Role::Dba, AuthType::Password);
+        let repo = Arc::new(CountingRepo::with_user(stored));
+        let repo_dyn: Arc<dyn UserRepository> = repo.clone();
+        let (token, _) =
+            jwt_auth::create_and_sign_token(&user_id, &Role::Dba, None, Some(1), secret)
+                .expect("sign access token");
+
+        let first = authenticate_bearer(&token, &connection_info(), &repo_dyn)
+            .await
+            .expect("first bearer auth");
+        let second = authenticate_bearer(&token, &connection_info(), &repo_dyn)
+            .await
+            .expect("cached bearer auth");
+
+        assert_eq!(first.user_id, user_id);
+        assert_eq!(second.user_id, user_id);
+        assert_eq!(second.role, Role::Dba);
+        assert_eq!(repo.lookup_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn authenticate_bearer_revalidates_after_user_session_invalidation() {
+        let _guard = bearer_cache_test_lock();
+        let secret = "bearer-session-cache-test-secret-32ch";
+        init_bearer_cache_jwt(secret);
+
+        let user_id = UserId::new("bearer_cache_invalidate");
+        let stored = test_user(user_id.clone(), Role::User, AuthType::Password);
+        let repo = Arc::new(CountingRepo::with_user(stored));
+        let repo_dyn: Arc<dyn UserRepository> = repo.clone();
+        let (token, _) =
+            jwt_auth::create_and_sign_token(&user_id, &Role::User, None, Some(1), secret)
+                .expect("sign access token");
+
+        authenticate_bearer(&token, &connection_info(), &repo_dyn)
+            .await
+            .expect("first bearer auth");
+        super::super::bearer_session_cache::invalidate_bearer_sessions(&user_id);
+        authenticate_bearer(&token, &connection_info(), &repo_dyn)
+            .await
+            .expect("bearer auth after invalidate");
+
+        assert_eq!(repo.lookup_count(), 2);
     }
 }

--- a/backend/crates/kalamdb-auth/src/services/unified/bearer_session_cache.rs
+++ b/backend/crates/kalamdb-auth/src/services/unified/bearer_session_cache.rs
@@ -1,0 +1,197 @@
+//! Verified-bearer session cache for the HTTP/SQL hot path.
+//!
+//! After a token has been signature-checked and the user resolved, later requests
+//! with the same token skip HMAC + user lookup. Expiry is still checked on every
+//! hit. User mutations bump a per-user epoch so cached sessions are dropped
+//! immediately (role change, delete, password update).
+
+use std::{
+    collections::HashMap,
+    sync::RwLock,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use kalamdb_commons::{
+    models::{ConnectionInfo, UserId},
+    AuthType, Role,
+};
+use moka::sync::Cache;
+use once_cell::sync::Lazy;
+
+use crate::models::context::AuthenticatedUser;
+
+const SESSION_CACHE_MAX_ENTRIES: u64 = 4096;
+const SESSION_CACHE_IDLE_TTL: Duration = Duration::from_secs(300);
+
+#[derive(Clone)]
+pub(super) struct CachedBearerIdentity {
+    user_id: UserId,
+    role: Role,
+    auth_type: AuthType,
+    email: Option<String>,
+    name: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+    exp: usize,
+    epoch: u64,
+}
+
+impl CachedBearerIdentity {
+    pub(super) fn from_authenticated_user(
+        user: &AuthenticatedUser,
+        exp: usize,
+        epoch: u64,
+    ) -> Self {
+        Self {
+            user_id: user.user_id.clone(),
+            role: user.role,
+            auth_type: user.auth_type,
+            email: user.email.clone(),
+            name: user.name.clone(),
+            created_at: user.created_at,
+            updated_at: user.updated_at,
+            exp,
+            epoch,
+        }
+    }
+
+    pub(super) fn into_authenticated_user(
+        self,
+        connection_info: &ConnectionInfo,
+    ) -> AuthenticatedUser {
+        AuthenticatedUser::with_auth_type(
+            self.user_id,
+            self.role,
+            self.auth_type,
+            self.email,
+            self.name,
+            self.created_at,
+            self.updated_at,
+            connection_info.clone(),
+        )
+    }
+}
+
+static SESSION_CACHE: Lazy<Cache<String, CachedBearerIdentity>> = Lazy::new(|| {
+    Cache::builder()
+        .max_capacity(SESSION_CACHE_MAX_ENTRIES)
+        .time_to_idle(SESSION_CACHE_IDLE_TTL)
+        .build()
+});
+
+static USER_EPOCHS: Lazy<RwLock<HashMap<UserId, u64>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+
+fn unix_now() -> usize {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as usize)
+        .unwrap_or(0)
+}
+
+pub(super) fn user_epoch(user_id: &UserId) -> u64 {
+    USER_EPOCHS
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(user_id)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Drop cached bearer sessions for `user_id` (role change, delete, password update).
+pub fn invalidate_bearer_sessions(user_id: &UserId) {
+    let mut epochs = USER_EPOCHS.write().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let next = epochs.get(user_id).copied().unwrap_or(0).saturating_add(1);
+    epochs.insert(user_id.clone(), next);
+}
+
+pub(super) fn lookup_cached_bearer_session(
+    token: &str,
+    connection_info: &ConnectionInfo,
+) -> Option<AuthenticatedUser> {
+    let cached = SESSION_CACHE.get(token)?;
+    if unix_now() >= cached.exp {
+        SESSION_CACHE.invalidate(token);
+        return None;
+    }
+    if cached.epoch != user_epoch(&cached.user_id) {
+        SESSION_CACHE.invalidate(token);
+        return None;
+    }
+    Some(cached.into_authenticated_user(connection_info))
+}
+
+pub(super) fn store_cached_bearer_session(token: &str, user: &AuthenticatedUser, exp: usize) {
+    if unix_now() >= exp {
+        return;
+    }
+    let epoch = user_epoch(&user.user_id);
+    SESSION_CACHE.insert(
+        token.to_string(),
+        CachedBearerIdentity::from_authenticated_user(user, exp, epoch),
+    );
+}
+
+#[cfg(test)]
+pub(super) fn clear_bearer_session_cache() {
+    SESSION_CACHE.invalidate_all();
+    SESSION_CACHE.run_pending_tasks();
+    USER_EPOCHS.write().unwrap_or_else(|poisoned| poisoned.into_inner()).clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_user(user_id: &str, role: Role) -> AuthenticatedUser {
+        AuthenticatedUser::with_auth_type(
+            UserId::new(user_id),
+            role,
+            AuthType::Password,
+            Some("user@example.com".to_string()),
+            Some("User".to_string()),
+            1,
+            2,
+            ConnectionInfo::new(Some("10.0.0.1".to_string())),
+        )
+    }
+
+    fn future_exp() -> usize {
+        unix_now().saturating_add(3600)
+    }
+
+    #[test]
+    fn cache_hit_reuses_identity_with_current_connection() {
+        clear_bearer_session_cache();
+        let user = test_user("cache_user_hit", Role::Dba);
+        store_cached_bearer_session("token-hit", &user, future_exp());
+
+        let current = ConnectionInfo::new(Some("127.0.0.1".to_string()));
+        let cached = lookup_cached_bearer_session("token-hit", &current).expect("cache hit");
+
+        assert_eq!(cached.user_id.as_str(), "cache_user_hit");
+        assert_eq!(cached.role, Role::Dba);
+        assert_eq!(cached.email.as_deref(), Some("user@example.com"));
+        assert_eq!(cached.connection_info.remote_addr.as_deref(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn expired_entry_is_not_returned() {
+        clear_bearer_session_cache();
+        let user = test_user("cache_user_exp", Role::User);
+        store_cached_bearer_session("token-exp", &user, unix_now().saturating_sub(1));
+
+        assert!(lookup_cached_bearer_session("token-exp", &user.connection_info).is_none());
+    }
+
+    #[test]
+    fn invalidate_user_drops_cached_session() {
+        clear_bearer_session_cache();
+        let user = test_user("cache_user_inv", Role::User);
+        store_cached_bearer_session("token-inv", &user, future_exp());
+        assert!(lookup_cached_bearer_session("token-inv", &user.connection_info).is_some());
+
+        invalidate_bearer_sessions(&user.user_id);
+
+        assert!(lookup_cached_bearer_session("token-inv", &user.connection_info).is_none());
+    }
+}

--- a/backend/crates/kalamdb-auth/src/services/unified/mod.rs
+++ b/backend/crates/kalamdb-auth/src/services/unified/mod.rs
@@ -2,6 +2,7 @@
 
 mod audit;
 mod bearer;
+mod bearer_session_cache;
 mod password;
 mod types;
 mod wire;
@@ -10,6 +11,7 @@ use std::sync::Arc;
 
 pub use audit::extract_user_id_for_audit;
 use bearer::authenticate_bearer;
+pub use bearer_session_cache::invalidate_bearer_sessions;
 use kalamdb_commons::{models::ConnectionInfo, Role};
 use once_cell::sync::Lazy;
 use password::authenticate_user_password;
@@ -54,6 +56,13 @@ pub async fn authenticate(
     connection_info: &kalamdb_commons::models::ConnectionInfo,
     repo: &Arc<dyn UserRepository>,
 ) -> AuthResult<AuthenticationResult> {
+    if let Some(user) = try_cached_auth_request(&request, connection_info) {
+        return Ok(AuthenticationResult {
+            user,
+            method: AuthMethod::Bearer,
+        });
+    }
+
     let request_kind = match &request {
         AuthRequest::Header(_) => "header",
         AuthRequest::Credentials { .. } => "credentials",
@@ -133,6 +142,28 @@ fn record_authenticated_span(user: &AuthenticatedUser) {
     tracing::Span::current().record("user", user.user_id.as_str());
 }
 
+/// Return a cached bearer identity when `auth_header` is a previously verified token.
+pub fn try_cached_bearer_session(
+    auth_header: &str,
+    connection_info: &ConnectionInfo,
+) -> Option<AuthenticatedUser> {
+    let token = extract_bearer_token(auth_header).ok()?;
+    bearer_session_cache::lookup_cached_bearer_session(token, connection_info)
+}
+
+fn try_cached_auth_request(
+    request: &AuthRequest,
+    connection_info: &ConnectionInfo,
+) -> Option<AuthenticatedUser> {
+    match request {
+        AuthRequest::Header(header) => try_cached_bearer_session(header, connection_info),
+        AuthRequest::Jwt { token } => {
+            bearer_session_cache::lookup_cached_bearer_session(token, connection_info)
+        },
+        AuthRequest::Credentials { .. } => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use kalamdb_commons::UserId;
@@ -144,6 +175,37 @@ mod tests {
         assert_eq!(format!("{:?}", AuthMethod::Basic), "Basic");
         assert_eq!(format!("{:?}", AuthMethod::Bearer), "Bearer");
         assert_eq!(format!("{:?}", AuthMethod::Direct), "Direct");
+    }
+
+    #[test]
+    fn try_cached_bearer_session_returns_stored_identity() {
+        use kalamdb_commons::{models::ConnectionInfo, AuthType, Role};
+
+        use crate::models::context::AuthenticatedUser;
+
+        bearer_session_cache::clear_bearer_session_cache();
+        let user = AuthenticatedUser::with_auth_type(
+            UserId::new("cache_header_user"),
+            Role::Dba,
+            AuthType::Password,
+            None,
+            None,
+            1,
+            2,
+            ConnectionInfo::new(Some("10.0.0.1".to_string())),
+        );
+        let exp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as usize)
+            .unwrap_or(0)
+            .saturating_add(3600);
+        bearer_session_cache::store_cached_bearer_session("header-token", &user, exp);
+
+        let cached = try_cached_bearer_session("Bearer header-token", &user.connection_info)
+            .expect("cache hit");
+        assert_eq!(cached.user_id.as_str(), "cache_header_user");
+        assert_eq!(cached.role, Role::Dba);
+        assert!(try_cached_bearer_session("Bearer missing", &user.connection_info).is_none());
     }
 
     #[test]

--- a/backend/crates/kalamdb-core/src/sql/executor/parameter_binding.rs
+++ b/backend/crates/kalamdb-core/src/sql/executor/parameter_binding.rs
@@ -5,7 +5,14 @@
 //! - DataFusion LogicalPlan placeholder replacement ($1, $2, ...)
 //! - ScalarValue type checking
 
-use datafusion::{common::ParamValues, logical_expr::LogicalPlan, scalar::ScalarValue};
+use datafusion::{
+    common::{
+        ParamValues,
+        tree_node::{Transformed, TransformedResult, TreeNode},
+    },
+    logical_expr::{Expr, LogicalPlan},
+    scalar::ScalarValue,
+};
 
 use crate::error::KalamDbError;
 
@@ -89,6 +96,47 @@ pub fn replace_placeholders_in_plan(
         })
 }
 
+fn placeholder_index(id: &str) -> Option<usize> {
+    let digits = id.strip_prefix('$').unwrap_or(id);
+    let index = digits.parse::<usize>().ok()?;
+    index.checked_sub(1)
+}
+
+/// Replace `$n` placeholders in a single expression. Used by the point-get fast
+/// path so a PK bind does not clone the full cached `LogicalPlan`.
+pub fn bind_placeholders_in_expr(expr: Expr, params: &[ScalarValue]) -> Result<Expr, KalamDbError> {
+    if params.is_empty() {
+        return Ok(expr);
+    }
+
+    let mut bind_error = None;
+    let bound = expr.transform_up(|node| {
+        let Expr::Placeholder(placeholder) = node else {
+            return Ok(Transformed::no(node));
+        };
+        let Some(index) = placeholder_index(&placeholder.id) else {
+            return Ok(Transformed::no(Expr::Placeholder(placeholder)));
+        };
+        let Some(value) = params.get(index) else {
+            bind_error = Some(KalamDbError::ParameterBindingError {
+                message: format!(
+                    "placeholder {} is out of range for {} parameters",
+                    placeholder.id,
+                    params.len()
+                ),
+            });
+            return Ok(Transformed::no(Expr::Placeholder(placeholder)));
+        };
+        Ok(Transformed::yes(Expr::Literal(value.clone(), None)))
+    });
+    if let Some(error) = bind_error {
+        return Err(error);
+    }
+    bound.data().map_err(|error| KalamDbError::ParameterBindingError {
+        message: error.to_string(),
+    })
+}
+
 /// Highest `$n` placeholder index in SQL (0 when none).
 pub fn max_placeholder_index(sql: &str) -> usize {
     let bytes = sql.as_bytes();
@@ -161,5 +209,24 @@ mod tests {
             ),
             2
         );
+    }
+
+    #[test]
+    fn bind_placeholders_in_expr_replaces_dollar_one() {
+        use datafusion::logical_expr::expr::Placeholder;
+
+        let expr = Expr::Placeholder(Placeholder::new_with_field("$1".to_string(), None));
+        let bound =
+            bind_placeholders_in_expr(expr, &[ScalarValue::Int64(Some(42))]).expect("bind $1");
+        assert_eq!(bound, Expr::Literal(ScalarValue::Int64(Some(42)), None));
+    }
+
+    #[test]
+    fn bind_placeholders_in_expr_out_of_range_errors() {
+        use datafusion::logical_expr::expr::Placeholder;
+
+        let expr = Expr::Placeholder(Placeholder::new_with_field("$2".to_string(), None));
+        let err = bind_placeholders_in_expr(expr, &[ScalarValue::Int64(Some(1))]).unwrap_err();
+        assert!(matches!(err, KalamDbError::ParameterBindingError { .. }));
     }
 }

--- a/backend/crates/kalamdb-core/src/sql/executor/sql_executor.rs
+++ b/backend/crates/kalamdb-core/src/sql/executor/sql_executor.rs
@@ -18,10 +18,10 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use kalamdb_commons::{
-    conversions::arrow_json_conversion::{arrow_value_to_scalar, json_rows_to_arrow_batch},
-    models::{rows::row::Row, MigrationId, NamespaceId, TableId, TransactionId, UserId},
-    schemas::TableType,
     Role, SystemTable,
+    conversions::arrow_json_conversion::{arrow_value_to_scalar, json_rows_to_arrow_batch},
+    models::{MigrationId, NamespaceId, TableId, TransactionId, UserId, rows::row::Row},
+    schemas::TableType,
 };
 use kalamdb_datafusion_sources::exec::DeferredBatchExec;
 use kalamdb_session_datafusion::ScanDiagnosticsContext;
@@ -36,21 +36,23 @@ use sqlparser::ast::{
 use uuid::Uuid;
 
 use super::{
-    point_read_session_cache_key::PointReadSessionCacheKey, PreparedExecutionStatement, SqlExecutor,
+    PreparedExecutionStatement, SqlExecutor, point_read_session_cache_key::PointReadSessionCacheKey,
 };
 use crate::{
     error::KalamDbError,
     sql::{
+        ExecutionContext, ExecutionResult,
         executor::{
             handler_registry::HandlerRegistry,
-            parameter_binding::{replace_placeholders_in_plan, validate_params},
+            parameter_binding::{
+                bind_placeholders_in_expr, replace_placeholders_in_plan, validate_params,
+            },
             request_transaction_state::{
-                map_request_transaction_error, AppContextRequestTransactionCoordinator,
-                RequestTransactionState,
+                AppContextRequestTransactionCoordinator, RequestTransactionState,
+                map_request_transaction_error,
             },
         },
         plan_cache::{PlanCacheKey, SqlCacheRegistry, SqlCacheRegistryConfig},
-        ExecutionContext, ExecutionResult,
     },
     transactions::CoordinatorAccessValidator,
 };
@@ -1475,9 +1477,13 @@ impl SqlExecutor {
     /// Execute a cached, optimized single-PK table scan without rebuilding a
     /// DataFusion logical/physical plan. Provider `scan` still enforces access,
     /// leader routing, transaction snapshots/overlays, MVCC, and tombstones.
+    ///
+    /// Placeholders are bound on the scan filters only — the cached template
+    /// plan is not cloned.
     async fn try_execute_cached_point_get(
         &self,
         plan: &LogicalPlan,
+        params: &[ScalarValue],
         exec_ctx: &ExecutionContext,
     ) -> Result<Option<ExecutionResult>, KalamDbError> {
         let LogicalPlan::TableScan(scan) = plan else {
@@ -1504,7 +1510,16 @@ impl SqlExecutor {
         let [primary_key] = primary_keys.as_slice() else {
             return Ok(None);
         };
-        if !scan.filters.iter().any(|filter| {
+
+        let mut filters = Vec::with_capacity(scan.filters.len());
+        for filter in &scan.filters {
+            let bound = match bind_placeholders_in_expr(filter.clone(), params) {
+                Ok(expr) => expr,
+                Err(_) => return Ok(None),
+            };
+            filters.push(Self::unqualify_scan_filter(bound)?);
+        }
+        if !filters.iter().any(|filter| {
             kalamdb_tables::utils::base::extract_pk_equality_literal(filter, primary_key).is_some()
         }) {
             return Ok(None);
@@ -1515,22 +1530,18 @@ impl SqlExecutor {
         };
         let state = self.point_read_session_state(exec_ctx)?;
         let limit = Some(scan.fetch.unwrap_or(1).min(1));
-        let filters = scan
-            .filters
-            .iter()
-            .cloned()
-            .map(Self::unqualify_scan_filter)
-            .collect::<Result<Vec<_>, _>>()?;
         let physical_plan = provider
             .scan(state.as_ref(), scan.projection.as_ref(), &filters, limit)
             .await
             .map_err(Self::datafusion_to_execution_error)?;
         let schema = physical_plan.schema();
         let batches = if let Some(deferred) = physical_plan.downcast_ref::<DeferredBatchExec>() {
-            vec![deferred
-                .produce_batch_direct()
-                .await
-                .map_err(Self::datafusion_to_execution_error)?]
+            vec![
+                deferred
+                    .produce_batch_direct()
+                    .await
+                    .map_err(Self::datafusion_to_execution_error)?,
+            ]
         } else {
             collect(physical_plan, state.task_ctx())
                 .await
@@ -2239,17 +2250,18 @@ impl SqlExecutor {
             PlanCacheKey::new(exec_ctx.default_namespace(), exec_ctx.user_role(), execution_sql);
 
         let df = if let Some(template_plan) = self.sql_cache_registry.plan_cache().get(&cache_key) {
+            if let Some(result) = self
+                .try_execute_cached_point_get(template_plan.as_ref(), &params, exec_ctx)
+                .await?
+            {
+                return Ok(result);
+            }
+
             let executable_plan = if params.is_empty() {
                 (*template_plan).clone()
             } else {
                 replace_placeholders_in_plan((*template_plan).clone(), &params)?
             };
-
-            if let Some(result) =
-                self.try_execute_cached_point_get(&executable_plan, exec_ctx).await?
-            {
-                return Ok(result);
-            }
 
             let session = self.create_session_with_transaction_context(exec_ctx)?;
             match session.execute_logical_plan(executable_plan).await {

--- a/backend/crates/kalamdb-tables/src/utils/base.rs
+++ b/backend/crates/kalamdb-tables/src/utils/base.rs
@@ -109,7 +109,8 @@ use kalamdb_datafusion_sources::{
 use kalamdb_filestore::registry::{ListResult, StorageCached};
 use kalamdb_session_datafusion::ScanDiagnosticsContext;
 use kalamdb_system::{
-    ClusterCoordinator as ClusterCoordinatorTrait, Manifest, SchemaRegistry as SchemaRegistryTrait,
+    ClusterCoordinator as ClusterCoordinatorTrait, Manifest, ManifestCacheEntry,
+    SchemaRegistry as SchemaRegistryTrait,
 };
 use kalamdb_transactions::{
     extract_transaction_query_context, TransactionAccessError, TransactionOverlay,
@@ -1106,6 +1107,15 @@ fn visible_hot_entry<K, V: ScanRow>(entry: Option<(K, V)>) -> Option<(K, V)> {
     entry.filter(|(_, row)| !row.deleted_flag())
 }
 
+/// Cached empty manifests mean there is no Parquet to merge.
+///
+/// Missing or failed loads return `false` so we still scan cold (manual
+/// `STORAGE FLUSH` and degraded listings can have files without a cached empty
+/// manifest).
+fn cached_manifest_is_hot_only(entry: Option<&ManifestCacheEntry>) -> bool {
+    entry.is_some_and(|cached| cached.manifest.segments.is_empty())
+}
+
 /// Resolve a single PK equality lookup by merging the latest hot and cold versions.
 async fn resolve_pk_point_lookup<P, K, V>(
     provider: &P,
@@ -1123,8 +1133,22 @@ where
     }
     let hot = visible_hot_entry(latest_hot);
 
-    // Always merge cold storage. Manual `STORAGE FLUSH` can materialize Parquet
-    // even when the table has no configured FLUSH_POLICY.
+    let skip_cold = match provider
+        .core()
+        .services
+        .manifest_service
+        .get_or_load_async(provider.table_id(), provider.scan_cold_scope(scan_context))
+        .await
+    {
+        Ok(entry) => cached_manifest_is_hot_only(entry.as_deref()),
+        Err(_) => false,
+    };
+    if skip_cold {
+        return Ok(hot);
+    }
+
+    // Merge cold when the manifest has segments, is missing, or failed to load.
+    // Manual `STORAGE FLUSH` can materialize Parquet even without FLUSH_POLICY.
     let cold =
         find_row_by_pk(provider, provider.scan_cold_scope(scan_context), &pk_scalar.to_string())
             .await?;
@@ -2107,6 +2131,23 @@ mod tests {
         fn deleted_flag(&self) -> bool {
             self.deleted
         }
+    }
+
+    #[test]
+    fn cached_empty_manifest_is_hot_only() {
+        let table_id = TableId::new(NamespaceId::new("ns"), TableName::new("t"));
+        let entry = ManifestCacheEntry::new(
+            Manifest::new(table_id, None),
+            None,
+            0,
+            kalamdb_system::SyncState::InSync,
+        );
+        assert!(cached_manifest_is_hot_only(Some(&entry)));
+    }
+
+    #[test]
+    fn missing_manifest_is_not_hot_only() {
+        assert!(!cached_manifest_is_hot_only(None));
     }
 
     #[test]

--- a/backend/crates/kalamdb-tables/src/utils/parquet.rs
+++ b/backend/crates/kalamdb-tables/src/utils/parquet.rs
@@ -78,35 +78,24 @@ async fn scan_parquet_files_internal_async(
     columns: Option<&[String]>,
     record_visited_files: bool,
 ) -> Result<ParquetScanResult, KalamDbError> {
-    let scope_label = user_id
-        .map(|uid| format!("user={}", uid.as_str()))
-        .unwrap_or_else(|| format!("scope={}", table_type.as_str()));
-
-    let manifest_service = core.services.manifest_service.clone();
-    log::trace!(
-        "[PARQUET_SCAN_ASYNC] About to get_or_load manifest: table={} {}",
-        table_id,
-        scope_label
-    );
-    let cache_result = manifest_service.get_or_load_async(table_id, user_id).await;
-    let mut manifest_entry = None;
-    let mut use_degraded_mode = false;
+    let cache_result = core.services.manifest_service.get_or_load_async(table_id, user_id).await;
 
     // Fast path: if manifest loaded successfully and has no segments,
     // skip the entire cold path (storage registry, planner, file I/O)
     if let Ok(Some(entry)) = &cache_result {
         if entry.manifest.segments.is_empty() {
-            log::trace!(
-                "[PARQUET_SCAN_ASYNC] Manifest empty, skipping cold path: table={} {}",
-                table_id,
-                scope_label
-            );
             return Ok(ParquetScanResult {
                 batch: RecordBatch::new_empty(schema),
                 stats: ParquetScanStats::default(),
             });
         }
     }
+
+    let scope_label = user_id
+        .map(|uid| format!("user={}", uid.as_str()))
+        .unwrap_or_else(|| format!("scope={}", table_type.as_str()));
+    let mut manifest_entry = None;
+    let mut use_degraded_mode = false;
 
     match &cache_result {
         Ok(Some(entry)) => {
@@ -118,14 +107,16 @@ async fn scan_parquet_files_internal_async(
                 entry.sync_state
             );
             // Validate manifest using service
-            if let Err(e) = manifest_service.validate_manifest(&entry.manifest) {
+            if let Err(e) = core.services.manifest_service.validate_manifest(&entry.manifest) {
                 log::warn!(
                     "⚠️  [MANIFEST CORRUPTION] table={} {} error={} | Triggering rebuild",
                     table_id,
                     scope_label,
                     e
                 );
-                if let Err(mark_err) = manifest_service.mark_as_stale(table_id, user_id) {
+                if let Err(mark_err) =
+                    core.services.manifest_service.mark_as_stale(table_id, user_id)
+                {
                     log::warn!(
                         "⚠️  Failed to mark manifest as stale: table={} {} error={}",
                         table_id,

--- a/link/sdks/typescript/orm/package-lock.json
+++ b/link/sdks/typescript/orm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kalamdb/orm",
-  "version": "0.5.5-rc.1",
+  "version": "0.5.6-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kalamdb/orm",
-      "version": "0.5.5-rc.1",
+      "version": "0.5.6-rc.0",
       "license": "Apache-2.0",
       "bin": {
         "kalamdb-orm": "dist/cli.js"
@@ -22,13 +22,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@kalamdb/client": ">=0.5.5-0 <0.6.0",
+        "@kalamdb/client": ">=0.5.6-0 <0.6.0",
         "drizzle-orm": ">=0.45.2"
       }
     },
     "../client": {
       "name": "@kalamdb/client",
-      "version": "0.5.5-rc.1",
+      "version": "0.5.6-rc.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -45,7 +45,7 @@
     },
     "../consumer": {
       "name": "@kalamdb/consumer",
-      "version": "0.5.5-rc.1",
+      "version": "0.5.6-rc.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -57,7 +57,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@kalamdb/client": ">=0.5.5-0 <0.6.0"
+        "@kalamdb/client": ">=0.5.6-0 <0.6.0"
       }
     },
     "node_modules/@kalamdb/client": {


### PR DESCRIPTION
## Summary

Keeps the cohort at **0.5.6-rc.0** and ships the SQL/auth hot-path speedups plus a custom GitHub release-notes input.

## What Changed

- [x] Feature
- [x] Tests

## Release notes

Paste this into the Release workflow `release_description` field:

```
## KalamDB 0.5.6-rc.0

Faster common SQL and auth requests.

### Performance
- Primary-key lookups skip empty Parquet scans when nothing has been flushed
- Repeated SQL queries reuse cached schema JSON and prepared-statement metadata
- Small SELECT results return as one JSON body instead of a streamed response
- Repeated bearer-token requests reuse a short-lived session cache (expiry is still checked; user changes drop the cache immediately)

### Other
- Release workflow can take your own GitHub release notes instead of auto-generating them
```

## Validation

```bash
python3 scripts/versions.py verify
```

`benchv2/comparison/` is intentionally not included.

## Checklist

- [x] I kept the change scoped to the problem being solved.
- [x] I added or updated tests when behavior changed.
- [x] I updated docs when the public behavior, workflow, or architecture changed.
- [x] If this touches auth, SQL, APIs, storage, or transport, I reviewed the security guidance in `SECURITY.md` and `docs/security/security-checklist.md`.

## Notes

After merge, run the Release workflow with **pre-release** enabled and the notes above.

Made with [Cursor](https://cursor.com)