### PR TITLE
Optimize V8 function session memory and warm reuse

### DIFF
--- a/backend/crates/kalamdb-functions/Cargo.toml
+++ b/backend/crates/kalamdb-functions/Cargo.toml
@@ -44,6 +44,7 @@ smallvec = { workspace = true }
 kalamdb-store = { path = "../kalamdb-store", optional = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 ntest = { workspace = true }
 kalamdb-serialization = { path = "../kalamdb-serialization" }
 
@@ -51,3 +52,7 @@ kalamdb-serialization = { path = "../kalamdb-serialization" }
 name = "kalamdb_functions"
 path = "src/lib.rs"
 doctest = false
+
+[[bench]]
+name = "v8_runtime"
+harness = false

--- a/backend/crates/kalamdb-functions/benches/v8_runtime.rs
+++ b/backend/crates/kalamdb-functions/benches/v8_runtime.rs
@@ -1,0 +1,84 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use datafusion_common::ScalarValue;
+use kalamdb_commons::RoutineId;
+use kalamdb_functions::{ModuleRevision, RoutineValue, RuntimeLimits, V8Session};
+use tokio_util::sync::CancellationToken;
+
+const SOURCE: &str = r#"
+function kalamInvoke(name, args) {
+  if (name === "echo") return args[0];
+  if (name === "math") {
+    let value = args[0];
+    for (let i = 0; i < 32; i++) value = (value * 1664525 + 1013904223) % 2147483647;
+    return value;
+  }
+  return null;
+}
+"#;
+
+fn warm_invoke(c: &mut Criterion) {
+    let mut session = V8Session::load(
+        ModuleRevision::typescript_fixture(SOURCE),
+        RuntimeLimits::default(),
+    )
+    .expect("load V8 session");
+    let id = RoutineId::new("echo");
+    let cancel = CancellationToken::new();
+    let arg = RoutineValue::new(ScalarValue::Int32(Some(42)));
+
+    c.bench_function("v8/warm_echo_with_context_reset", |b| {
+        b.iter(|| {
+            let value = session
+                .invoke(black_box(&id), black_box(std::slice::from_ref(&arg)), &cancel)
+                .expect("invoke");
+            black_box(value);
+        });
+    });
+}
+
+fn warm_cpu_function(c: &mut Criterion) {
+    let mut session = V8Session::load(
+        ModuleRevision::typescript_fixture(SOURCE),
+        RuntimeLimits::default(),
+    )
+    .expect("load V8 session");
+    let id = RoutineId::new("math");
+    let cancel = CancellationToken::new();
+    let arg = RoutineValue::new(ScalarValue::Float64(Some(12345.0)));
+
+    c.bench_function("v8/warm_cpu_function", |b| {
+        b.iter(|| {
+            let value = session
+                .invoke(black_box(&id), black_box(std::slice::from_ref(&arg)), &cancel)
+                .expect("invoke");
+            black_box(value);
+        });
+    });
+}
+
+fn cold_session(c: &mut Criterion) {
+    let revision = ModuleRevision::typescript_fixture(SOURCE);
+    let id = RoutineId::new("echo");
+    let arg = RoutineValue::new(ScalarValue::Int32(Some(42)));
+
+    c.bench_function("v8/cold_session_plus_first_invoke", |b| {
+        b.iter_batched(
+            || revision.clone(),
+            |revision| {
+                let mut session =
+                    V8Session::load(revision, RuntimeLimits::default()).expect("load V8 session");
+                let cancel = CancellationToken::new();
+                let value = session
+                    .invoke(black_box(&id), black_box(std::slice::from_ref(&arg)), &cancel)
+                    .expect("invoke");
+                black_box(value);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(benches, warm_invoke, warm_cpu_function, cold_session);
+criterion_main!(benches);

--- a/backend/crates/kalamdb-functions/src/engine/engine.rs
+++ b/backend/crates/kalamdb-functions/src/engine/engine.rs
@@ -2,13 +2,14 @@
 
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::VecDeque,
     rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
     thread,
+    time::{Duration, Instant},
 };
 
 use kalamdb_commons::FunctionRevisionId;
@@ -26,18 +27,130 @@ struct Work {
     reply:      oneshot::Sender<Result<RoutineValue>>,
     _active:    Option<OwnedSemaphorePermit>,
     _root:      Option<OwnedSemaphorePermit>,
-    _memory:    MemoryCharge,
 }
 
+/// A reservation for the lifetime of a V8 isolate, including while it is warm/idle.
+///
+/// Previously memory was charged to `Work`, which meant the reservation disappeared as soon as an
+/// invocation completed even when its isolate stayed resident in the idle cache. Keeping the charge
+/// with the isolate makes `max_memory_bytes` describe resident function-runtime capacity instead of
+/// only in-flight calls.
 struct MemoryCharge {
     used:   Arc<AtomicUsize>,
     amount: usize,
 }
 
+impl MemoryCharge {
+    fn try_new(used: Arc<AtomicUsize>, amount: usize, limit: usize) -> Result<Self> {
+        loop {
+            let current = used.load(Ordering::Acquire);
+            let Some(next) = current.checked_add(amount) else {
+                return Err(FunctionsError::ResourceLimit("function memory".into()));
+            };
+            if next > limit {
+                return Err(FunctionsError::ResourceLimit("function memory".into()));
+            }
+            if used
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return Ok(Self { used, amount });
+            }
+        }
+    }
+}
+
 impl Drop for MemoryCharge {
     fn drop(&mut self) {
-        self.used.fetch_sub(self.amount, Ordering::Relaxed);
+        self.used.fetch_sub(self.amount, Ordering::AcqRel);
     }
+}
+
+/// One V8 isolate plus the lifecycle information needed to decide whether keeping it warm is still
+/// worthwhile. The memory reservation intentionally lives in this wrapper, not in an invocation.
+struct SessionInstance {
+    session:     V8Session,
+    created_at:  Instant,
+    last_used_at: Instant,
+    invocations: u64,
+    _memory:     MemoryCharge,
+}
+
+impl SessionInstance {
+    fn new(session: V8Session, memory: MemoryCharge, now: Instant) -> Self {
+        Self {
+            session,
+            created_at: now,
+            last_used_at: now,
+            invocations: 0,
+            _memory: memory,
+        }
+    }
+
+    fn expired(&self, now: Instant, config: &EngineConfig) -> bool {
+        now.saturating_duration_since(self.last_used_at) >= config.idle_ttl
+            || now.saturating_duration_since(self.created_at) >= config.max_instance_age
+            || self.invocations >= config.max_invocations_per_instance
+    }
+}
+
+/// Per-worker LRU of detached V8 isolates.
+///
+/// A `VecDeque` is deliberate: `max_idle_per_lane` is small, and unlike the previous
+/// `HashMap<revision, session>` it supports more than one warm instance of a revision and does not
+/// accidentally discard every other revision when one function is recycled.
+#[derive(Default)]
+struct IdlePool {
+    sessions: VecDeque<SessionInstance>,
+}
+
+impl IdlePool {
+    fn take(
+        &mut self,
+        revision_id: &FunctionRevisionId,
+        now: Instant,
+        config: &EngineConfig,
+    ) -> Option<SessionInstance> {
+        self.prune(now, config);
+        let index = self
+            .sessions
+            .iter()
+            .rposition(|instance| &instance.session.revision.revision_id == revision_id)?;
+        self.sessions.remove(index)
+    }
+
+    fn recycle(&mut self, mut instance: SessionInstance, now: Instant, config: &EngineConfig) {
+        self.prune(now, config);
+        if config.max_idle_per_lane == 0 || instance.expired(now, config) {
+            return;
+        }
+
+        instance.last_used_at = now;
+        instance.session.detach();
+        while self.sessions.len() >= config.max_idle_per_lane {
+            self.sessions.pop_front();
+        }
+        self.sessions.push_back(instance);
+    }
+
+    fn prune(&mut self, now: Instant, config: &EngineConfig) {
+        self.sessions.retain(|instance| !instance.expired(now, config));
+    }
+
+    fn evict_lru(&mut self) -> bool {
+        self.sessions.pop_front().is_some()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.sessions.len()
+    }
+}
+
+fn idle_sweep_interval(ttl: Duration) -> Duration {
+    // Sweep quickly enough for small test/operator TTLs without waking every worker continuously.
+    // A zero TTL means "do not retain idle sessions" and still uses a small maintenance interval.
+    ttl.min(Duration::from_secs(1)).max(Duration::from_millis(10))
 }
 
 pub struct FunctionEngine {
@@ -54,10 +167,12 @@ pub struct FunctionEngine {
 impl FunctionEngine {
     pub fn new(config: EngineConfig) -> Result<Self> {
         config.validate()?;
+        let memory = Arc::new(AtomicUsize::new(0));
         let mut workers = Vec::with_capacity(config.workers);
         for index in 0..config.workers {
             let (sender, mut receiver) = mpsc::channel::<Work>(config.max_active);
             let worker_config = config.clone();
+            let worker_memory = Arc::clone(&memory);
             thread::Builder::new()
                 .name(format!("functions-{index}"))
                 .spawn(move || {
@@ -67,25 +182,41 @@ impl FunctionEngine {
                         .expect("function worker runtime");
                     let local = tokio::task::LocalSet::new();
                     local.block_on(&runtime, async move {
-                        let idle =
-                            Rc::new(RefCell::new(HashMap::<FunctionRevisionId, V8Session>::new()));
-                        while let Some(work) = receiver.recv().await {
-                            let idle = Rc::clone(&idle);
-                            let config = worker_config.clone();
-                            tokio::task::spawn_local(async move {
-                                let result = run_v8(&work, &config, &idle).await;
-                                let result = result.and_then(|value| {
-                                    if value.value.size() > config.max_value_bytes {
-                                        Err(FunctionsError::ResourceLimit(
-                                            "procedure result bytes".into(),
-                                        ))
-                                    } else {
-                                        Ok(value)
-                                    }
-                                });
-                                let _ = work.reply.send(result);
-                            });
+                        let idle = Rc::new(RefCell::new(IdlePool::default()));
+                        let mut sweep = tokio::time::interval(idle_sweep_interval(worker_config.idle_ttl));
+                        sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+                        loop {
+                            tokio::select! {
+                                maybe_work = receiver.recv() => {
+                                    let Some(work) = maybe_work else {
+                                        break;
+                                    };
+                                    let idle = Rc::clone(&idle);
+                                    let config = worker_config.clone();
+                                    let memory = Arc::clone(&worker_memory);
+                                    tokio::task::spawn_local(async move {
+                                        let result = run_v8(&work, &config, &idle, &memory).await;
+                                        let result = result.and_then(|value| {
+                                            if value.value.size() > config.max_value_bytes {
+                                                Err(FunctionsError::ResourceLimit(
+                                                    "procedure result bytes".into(),
+                                                ))
+                                            } else {
+                                                Ok(value)
+                                            }
+                                        });
+                                        let _ = work.reply.send(result);
+                                    });
+                                },
+                                _ = sweep.tick() => {
+                                    idle.borrow_mut().prune(Instant::now(), &worker_config);
+                                },
+                            }
                         }
+
+                        // Do not leave detached isolates resident after engine shutdown.
+                        idle.borrow_mut().sessions.clear();
                     });
                     runtime.block_on(local);
                 })
@@ -98,7 +229,7 @@ impl FunctionEngine {
             roots: Arc::new(Semaphore::new(config.max_active - config.nested_reserve)),
             active: Arc::new(Semaphore::new(config.max_active)),
             queued: Arc::new(Semaphore::new(config.max_queued)),
-            memory: Arc::new(AtomicUsize::new(0)),
+            memory,
             revisions: Cache::builder()
                 .max_capacity(config.cache_bytes)
                 .weigher(|_: &FunctionRevisionId, revision: &Arc<ModuleRevision>| {
@@ -177,24 +308,17 @@ impl FunctionEngine {
         } else {
             None
         };
-        let charge = invocation.revision.byte_len().saturating_add(self.config.max_heap_bytes);
-        loop {
-            let current = self.memory.load(Ordering::Relaxed);
-            if current.saturating_add(charge) > self.config.max_memory_bytes {
-                return Err(FunctionsError::ResourceLimit("function memory".into()));
-            }
-            if self
-                .memory
-                .compare_exchange(current, current + charge, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
+
+        // A session owns its memory reservation. Reject an impossible artifact up front, but defer
+        // the actual reservation to the worker because a matching warm isolate may already own it.
+        let session_charge = invocation
+            .revision
+            .byte_len()
+            .saturating_add(self.config.max_heap_bytes);
+        if session_charge > self.config.max_memory_bytes {
+            return Err(FunctionsError::ResourceLimit("function memory".into()));
         }
-        let memory = MemoryCharge {
-            used:   Arc::clone(&self.memory),
-            amount: charge,
-        };
+
         let (reply, response) = oneshot::channel();
         let cancel = invocation.scope.cancel.clone();
         let deadline = invocation.scope.deadline;
@@ -207,7 +331,6 @@ impl FunctionEngine {
                 reply,
                 _active: active,
                 _root: root,
-                _memory: memory,
             })
             .map_err(|_| FunctionsError::Capacity)?;
         // The worker acknowledges cleanup before the caller can roll back.
@@ -222,10 +345,32 @@ impl FunctionEngine {
     }
 }
 
+fn reserve_session_memory(
+    memory: &Arc<AtomicUsize>,
+    amount: usize,
+    config: &EngineConfig,
+    idle: &Rc<RefCell<IdlePool>>,
+) -> Result<MemoryCharge> {
+    loop {
+        match MemoryCharge::try_new(Arc::clone(memory), amount, config.max_memory_bytes) {
+            Ok(charge) => return Ok(charge),
+            Err(error) => {
+                // Under pressure, a cold invocation is more valuable than an unrelated warm LRU.
+                // Evicting locally also keeps V8 destruction on the isolate's owning worker.
+                if idle.borrow_mut().evict_lru() {
+                    continue;
+                }
+                return Err(error);
+            },
+        }
+    }
+}
+
 async fn run_v8(
     work: &Work,
     config: &EngineConfig,
-    idle: &Rc<RefCell<HashMap<FunctionRevisionId, V8Session>>>,
+    idle: &Rc<RefCell<IdlePool>>,
+    memory: &Arc<AtomicUsize>,
 ) -> Result<RoutineValue> {
     work.invocation.scope.check()?;
     let limits = RuntimeLimits {
@@ -233,30 +378,43 @@ async fn run_v8(
             .invocation
             .scope
             .deadline
-            .saturating_duration_since(std::time::Instant::now()),
+            .saturating_duration_since(Instant::now()),
         max_heap_bytes: config.max_heap_bytes,
         abi_version:    work.invocation.revision.abi_version,
     };
     let revision_id = work.invocation.revision.revision_id.clone();
-    let cached = idle.borrow_mut().remove(&revision_id);
-    let mut session = match cached {
-        Some(mut session) => {
-            session.limits = limits;
-            session
+    let now = Instant::now();
+    let cached = idle.borrow_mut().take(&revision_id, now, config);
+    let mut instance = match cached {
+        Some(mut instance) => {
+            instance.session.limits = limits;
+            instance
         },
-        None => V8Session::load((*work.invocation.revision).clone(), limits)?,
+        None => {
+            let amount = work
+                .invocation
+                .revision
+                .byte_len()
+                .saturating_add(config.max_heap_bytes);
+            let memory_charge = reserve_session_memory(memory, amount, config, idle)?;
+            let session = V8Session::load((*work.invocation.revision).clone(), limits)?;
+            SessionInstance::new(session, memory_charge, now)
+        },
     };
-    let result = session.invoke_async(&work.invocation, Arc::clone(&work.host)).await;
+
+    let result = instance
+        .session
+        .invoke_async(&work.invocation, Arc::clone(&work.host))
+        .await;
+    instance.invocations = instance.invocations.saturating_add(1);
+
+    let completed_at = Instant::now();
     let recycle = result.is_ok()
-        && !session.heap_limit_hit()
-        && session.used_heap_bytes() <= config.heap_soft_bytes;
+        && !instance.session.heap_limit_hit()
+        && instance.session.used_heap_bytes() <= config.heap_soft_bytes
+        && !instance.expired(completed_at, config);
     if recycle {
-        session.detach();
-        let mut pool = idle.borrow_mut();
-        pool.retain(|id, _| id == &revision_id);
-        if pool.len() < config.max_idle_per_lane.max(1) {
-            pool.insert(revision_id, session);
-        }
+        idle.borrow_mut().recycle(instance, completed_at, config);
     }
     result
 }
@@ -294,7 +452,7 @@ mod tests {
     };
 
     use datafusion_common::ScalarValue;
-    use kalamdb_commons::RoutineId;
+    use kalamdb_commons::{ArtifactId, FunctionModuleId, FunctionRevisionId, RoutineId};
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -323,6 +481,31 @@ mod tests {
         }
         fn is_http_root(&self) -> bool {
             false
+        }
+    }
+
+    fn revision(label: &str) -> Arc<ModuleRevision> {
+        let source = "function kalamInvoke(name, args) { return args[0] ?? 0; }";
+        let module_id = FunctionModuleId::new("backend");
+        let artifact_id = ArtifactId::new(label);
+        let mut revision = ModuleRevision::typescript_fixture(source);
+        revision.module_id = module_id.clone();
+        revision.artifact_id = artifact_id.clone();
+        revision.revision_id = FunctionRevisionId::from_module_artifact(&module_id, &artifact_id);
+        Arc::new(revision)
+    }
+
+    fn invocation(revision: Arc<ModuleRevision>, depth: usize, value: i32) -> Invocation {
+        Invocation {
+            routine_id: RoutineId::new("echo"),
+            revision,
+            args: vec![RoutineValue::new(ScalarValue::Int32(Some(value)))],
+            scope: InvocationScope {
+                deadline: Instant::now() + Duration::from_secs(5),
+                cancel: CancellationToken::new(),
+                depth,
+            },
+            return_template: None,
         }
     }
 
@@ -396,5 +579,167 @@ mod tests {
         assert!(matches!(err, FunctionsError::Timeout | FunctionsError::Cancelled));
         let value = engine.invoke(echo_invocation(0, 4), Arc::new(NoopHost)).await.unwrap();
         assert_eq!(value.value, ScalarValue::Int32(Some(4)));
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(15000)]
+    async fn zero_idle_capacity_releases_v8_memory_after_each_call() {
+        let mut config = EngineConfig::default();
+        config.workers = 1;
+        config.max_active = 1;
+        config.max_idle_per_lane = 0;
+        let engine = FunctionEngine::new(config).unwrap();
+
+        let value = engine
+            .invoke(invocation(revision("no-idle"), 0, 7), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert_eq!(value.value, ScalarValue::Int32(Some(7)));
+        assert_eq!(
+            engine.memory.load(Ordering::Acquire),
+            0,
+            "max_idle_per_lane=0 must not leave a resident isolate charged after completion"
+        );
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(15000)]
+    async fn idle_ttl_reclaims_resident_session_memory_without_more_requests() {
+        let mut config = EngineConfig::default();
+        config.workers = 1;
+        config.max_active = 1;
+        config.max_idle_per_lane = 1;
+        config.idle_ttl = Duration::from_millis(40);
+        let engine = FunctionEngine::new(config).unwrap();
+
+        engine
+            .invoke(invocation(revision("ttl"), 0, 1), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert!(engine.memory.load(Ordering::Acquire) > 0);
+
+        for _ in 0..100 {
+            if engine.memory.load(Ordering::Acquire) == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            engine.memory.load(Ordering::Acquire),
+            0,
+            "idle TTL maintenance must reclaim a warm isolate even with no later invocation"
+        );
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(20000)]
+    async fn idle_pool_keeps_multiple_revisions_when_capacity_allows() {
+        let mut config = EngineConfig::default();
+        config.workers = 1;
+        config.max_active = 1;
+        config.max_idle_per_lane = 2;
+        config.idle_ttl = Duration::from_secs(30);
+        config.max_memory_bytes = config.max_heap_bytes * 3;
+        let first = revision("first");
+        let second = revision("second");
+        let expected = config.max_heap_bytes * 2 + first.byte_len() + second.byte_len();
+        let engine = FunctionEngine::new(config).unwrap();
+
+        engine
+            .invoke(invocation(Arc::clone(&first), 0, 1), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        engine
+            .invoke(invocation(Arc::clone(&second), 0, 2), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert_eq!(engine.memory.load(Ordering::Acquire), expected);
+
+        // This used to evict `second` because recycling `first` retained only its own revision ID.
+        engine
+            .invoke(invocation(first, 0, 3), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert_eq!(engine.memory.load(Ordering::Acquire), expected);
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(20000)]
+    async fn memory_pressure_evicts_local_warm_lru_before_rejecting_cold_function() {
+        let mut config = EngineConfig::default();
+        config.workers = 1;
+        config.max_active = 1;
+        config.max_idle_per_lane = 2;
+        config.idle_ttl = Duration::from_secs(30);
+        // Enough for two warm isolates, deliberately not three.
+        config.max_memory_bytes = config.max_heap_bytes * 2 + 4096;
+        let limit = config.max_memory_bytes;
+        let engine = FunctionEngine::new(config).unwrap();
+
+        for (label, value) in [("a", 1), ("b", 2), ("c", 3)] {
+            let result = engine
+                .invoke(invocation(revision(label), 0, value), Arc::new(NoopHost))
+                .await
+                .unwrap();
+            assert_eq!(result.value, ScalarValue::Int32(Some(value)));
+        }
+        assert!(engine.memory.load(Ordering::Acquire) <= limit);
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(20000)]
+    async fn invocation_limit_rotates_old_isolate_instead_of_retaining_it_forever() {
+        let mut config = EngineConfig::default();
+        config.workers = 1;
+        config.max_active = 1;
+        config.max_idle_per_lane = 1;
+        config.max_invocations_per_instance = 2;
+        config.idle_ttl = Duration::from_secs(30);
+        let engine = FunctionEngine::new(config).unwrap();
+        let rev = revision("rotation");
+
+        engine
+            .invoke(invocation(Arc::clone(&rev), 0, 1), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert!(engine.memory.load(Ordering::Acquire) > 0);
+
+        engine
+            .invoke(invocation(Arc::clone(&rev), 0, 2), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert_eq!(
+            engine.memory.load(Ordering::Acquire),
+            0,
+            "the instance must be retired once its invocation budget is consumed"
+        );
+
+        engine
+            .invoke(invocation(rev, 0, 3), Arc::new(NoopHost))
+            .await
+            .unwrap();
+        assert!(engine.memory.load(Ordering::Acquire) > 0);
+    }
+
+    #[test]
+    fn idle_sweep_interval_is_bounded() {
+        assert_eq!(idle_sweep_interval(Duration::ZERO), Duration::from_millis(10));
+        assert_eq!(idle_sweep_interval(Duration::from_millis(50)), Duration::from_millis(50));
+        assert_eq!(idle_sweep_interval(Duration::from_secs(30)), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn memory_charge_tracks_resident_lifetime() {
+        let used = Arc::new(AtomicUsize::new(0));
+        let charge = MemoryCharge::try_new(Arc::clone(&used), 64, 128).unwrap();
+        assert_eq!(used.load(Ordering::Acquire), 64);
+        assert!(MemoryCharge::try_new(Arc::clone(&used), 80, 128).is_err());
+        drop(charge);
+        assert_eq!(used.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn idle_pool_default_is_empty() {
+        assert_eq!(IdlePool::default().len(), 0);
     }
 }

--- a/backend/crates/kalamdb-functions/src/engine/engine.rs
+++ b/backend/crates/kalamdb-functions/src/engine/engine.rs
@@ -3,6 +3,7 @@
 use std::{
     cell::RefCell,
     collections::VecDeque,
+    hash::{DefaultHasher, Hash, Hasher},
     rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -69,11 +70,11 @@ impl Drop for MemoryCharge {
 /// One V8 isolate plus the lifecycle information needed to decide whether keeping it warm is still
 /// worthwhile. The memory reservation intentionally lives in this wrapper, not in an invocation.
 struct SessionInstance {
-    session:     V8Session,
-    created_at:  Instant,
+    session:      V8Session,
+    created_at:   Instant,
     last_used_at: Instant,
-    invocations: u64,
-    _memory:     MemoryCharge,
+    invocations:  u64,
+    _memory:      MemoryCharge,
 }
 
 impl SessionInstance {
@@ -87,10 +88,16 @@ impl SessionInstance {
         }
     }
 
-    fn expired(&self, now: Instant, config: &EngineConfig) -> bool {
-        now.saturating_duration_since(self.last_used_at) >= config.idle_ttl
-            || now.saturating_duration_since(self.created_at) >= config.max_instance_age
+    /// Limits tied to the isolate itself, independent of how long it has been idle.
+    fn lifecycle_expired(&self, now: Instant, config: &EngineConfig) -> bool {
+        now.saturating_duration_since(self.created_at) >= config.max_instance_age
             || self.invocations >= config.max_invocations_per_instance
+    }
+
+    fn idle_expired(&self, now: Instant, config: &EngineConfig) -> bool {
+        config.idle_ttl.is_zero()
+            || now.saturating_duration_since(self.last_used_at) >= config.idle_ttl
+            || self.lifecycle_expired(now, config)
     }
 }
 
@@ -121,10 +128,14 @@ impl IdlePool {
 
     fn recycle(&mut self, mut instance: SessionInstance, now: Instant, config: &EngineConfig) {
         self.prune(now, config);
-        if config.max_idle_per_lane == 0 || instance.expired(now, config) {
+        if config.max_idle_per_lane == 0
+            || config.idle_ttl.is_zero()
+            || instance.lifecycle_expired(now, config)
+        {
             return;
         }
 
+        // Idle time starts after execution completes, not when the invocation began.
         instance.last_used_at = now;
         instance.session.detach();
         while self.sessions.len() >= config.max_idle_per_lane {
@@ -134,7 +145,7 @@ impl IdlePool {
     }
 
     fn prune(&mut self, now: Instant, config: &EngineConfig) {
-        self.sessions.retain(|instance| !instance.expired(now, config));
+        self.sessions.retain(|instance| !instance.idle_expired(now, config));
     }
 
     fn evict_lru(&mut self) -> bool {
@@ -153,15 +164,24 @@ fn idle_sweep_interval(ttl: Duration) -> Duration {
     ttl.min(Duration::from_secs(1)).max(Duration::from_millis(10))
 }
 
+/// Prefer the same worker for a revision so sequential calls reuse one warm isolate instead of
+/// round-robin warming the same function on every worker. The sender falls back to other workers
+/// when this preferred lane is full, preserving parallelism for hot functions under load.
+fn preferred_worker(revision_id: &FunctionRevisionId, workers: usize) -> usize {
+    debug_assert!(workers > 0);
+    let mut hasher = DefaultHasher::new();
+    revision_id.hash(&mut hasher);
+    (hasher.finish() as usize) % workers
+}
+
 pub struct FunctionEngine {
-    config:      EngineConfig,
-    workers:     Vec<mpsc::Sender<Work>>,
-    next_worker: AtomicUsize,
-    active:      Arc<Semaphore>,
-    roots:       Arc<Semaphore>,
-    queued:      Arc<Semaphore>,
-    memory:      Arc<AtomicUsize>,
-    revisions:   Cache<FunctionRevisionId, Arc<ModuleRevision>>,
+    config:    EngineConfig,
+    workers:   Vec<mpsc::Sender<Work>>,
+    active:    Arc<Semaphore>,
+    roots:     Arc<Semaphore>,
+    queued:    Arc<Semaphore>,
+    memory:    Arc<AtomicUsize>,
+    revisions: Cache<FunctionRevisionId, Arc<ModuleRevision>>,
 }
 
 impl FunctionEngine {
@@ -183,7 +203,8 @@ impl FunctionEngine {
                     let local = tokio::task::LocalSet::new();
                     local.block_on(&runtime, async move {
                         let idle = Rc::new(RefCell::new(IdlePool::default()));
-                        let mut sweep = tokio::time::interval(idle_sweep_interval(worker_config.idle_ttl));
+                        let mut sweep =
+                            tokio::time::interval(idle_sweep_interval(worker_config.idle_ttl));
                         sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
                         loop {
@@ -238,7 +259,6 @@ impl FunctionEngine {
                 .build(),
             config,
             workers,
-            next_worker: AtomicUsize::new(0),
         })
     }
 
@@ -319,20 +339,36 @@ impl FunctionEngine {
             return Err(FunctionsError::ResourceLimit("function memory".into()));
         }
 
+        let preferred = preferred_worker(&invocation.revision.revision_id, self.workers.len());
         let (reply, response) = oneshot::channel();
         let cancel = invocation.scope.cancel.clone();
         let deadline = invocation.scope.deadline;
         let cancellation = cancel.clone().drop_guard();
-        let index = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.workers.len();
-        self.workers[index]
-            .try_send(Work {
-                invocation,
-                host,
-                reply,
-                _active: active,
-                _root: root,
-            })
-            .map_err(|_| FunctionsError::Capacity)?;
+        let mut work = Work {
+            invocation,
+            host,
+            reply,
+            _active: active,
+            _root: root,
+        };
+        let mut sent = false;
+        for offset in 0..self.workers.len() {
+            let index = (preferred + offset) % self.workers.len();
+            match self.workers[index].try_send(work) {
+                Ok(()) => {
+                    sent = true;
+                    break;
+                },
+                Err(mpsc::error::TrySendError::Full(returned))
+                | Err(mpsc::error::TrySendError::Closed(returned)) => {
+                    work = returned;
+                },
+            }
+        }
+        if !sent {
+            return Err(FunctionsError::Capacity);
+        }
+
         // The worker acknowledges cleanup before the caller can roll back.
         let result = tokio::select! {
             biased;
@@ -412,7 +448,7 @@ async fn run_v8(
     let recycle = result.is_ok()
         && !instance.session.heap_limit_hit()
         && instance.session.used_heap_bytes() <= config.heap_soft_bytes
-        && !instance.expired(completed_at, config);
+        && !instance.lifecycle_expired(completed_at, config);
     if recycle {
         idle.borrow_mut().recycle(instance, completed_at, config);
     }
@@ -665,6 +701,33 @@ mod tests {
 
     #[tokio::test]
     #[ntest::timeout(20000)]
+    async fn revision_affinity_avoids_warming_same_function_on_every_worker() {
+        let mut config = EngineConfig::default();
+        config.workers = 4;
+        config.max_active = 4;
+        config.max_idle_per_lane = 1;
+        config.idle_ttl = Duration::from_secs(30);
+        config.max_memory_bytes = config.max_heap_bytes * 2;
+        let rev = revision("sticky");
+        let expected = config.max_heap_bytes + rev.byte_len();
+        let engine = FunctionEngine::new(config).unwrap();
+
+        for value in 0..8 {
+            let result = engine
+                .invoke(invocation(Arc::clone(&rev), 0, value), Arc::new(NoopHost))
+                .await
+                .unwrap();
+            assert_eq!(result.value, ScalarValue::Int32(Some(value)));
+        }
+        assert_eq!(
+            engine.memory.load(Ordering::Acquire),
+            expected,
+            "sequential calls should stay on the preferred worker and reuse one warm isolate"
+        );
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(20000)]
     async fn memory_pressure_evicts_local_warm_lru_before_rejecting_cold_function() {
         let mut config = EngineConfig::default();
         config.workers = 1;
@@ -719,6 +782,13 @@ mod tests {
             .await
             .unwrap();
         assert!(engine.memory.load(Ordering::Acquire) > 0);
+    }
+
+    #[test]
+    fn worker_affinity_is_stable_for_same_revision() {
+        let id = FunctionRevisionId::new("backend:abc");
+        assert_eq!(preferred_worker(&id, 4), preferred_worker(&id, 4));
+        assert!(preferred_worker(&id, 4) < 4);
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

- Replace the per-worker single-revision idle map with a bounded LRU warm-session pool.
- Keep function memory reservations alive for the full V8 isolate lifetime, including while idle.
- Honor `max_idle_per_lane = 0` as a true no-idle-memory mode.
- Enforce idle TTL, maximum instance age, and maximum invocations per V8 instance.
- Periodically reclaim expired idle isolates even when no new function calls arrive.
- Evict a local warm LRU under memory pressure before rejecting a cold function.
- Add revision-to-worker affinity with spillover: normal sequential calls reuse one lane/isolate, while a full preferred lane spills to other workers for parallelism.
- Add lifecycle/memory regression tests for idle reclamation, multiple revisions, affinity, rotation, and pressure.
- Add Criterion benchmarks for warm invocation, CPU work, and cold start.

## Why

The previous pool retained only the current revision (`retain(|id| id == current_revision)`), which discarded other warm revisions and prevented the configured idle capacity from behaving as intended. More importantly, memory accounting was attached to an invocation rather than the retained V8 isolate, so `max_memory_bytes` stopped accounting for memory as soon as a function became idle.

Round-robin dispatch also warmed the same revision independently on multiple workers during ordinary sequential traffic. Revision affinity reduces that duplicate resident memory and increases warm-cache hit rate, while spillover keeps parallel execution available when a preferred worker is busy.

This PR makes resident V8 capacity explicit and bounded, allowing deployments to trade warm throughput against idle memory predictably.

## Validation

Added unit/regression coverage plus a benchmark target:

`cargo bench -p kalamdb-functions --bench v8_runtime`

Note: this repository's current CI workflow is configured for pushes to `main` or manual dispatch, not pull requests, so this draft PR does not automatically run Cargo CI. It should remain draft until `cargo test -p kalamdb-functions` and the benchmark target have been run in a build-capable environment.
